### PR TITLE
Changes the schema

### DIFF
--- a/jupyter_ydoc/ydoc.py
+++ b/jupyter_ydoc/ydoc.py
@@ -92,7 +92,7 @@ class YNotebook(YBaseDoc):
             if "id" in cell and meta["nbformat"] == 4 and meta["nbformat_minor"] <= 4:
                 # strip cell IDs if we have notebook format 4.0-4.4
                 del cell["id"]
-            if (cell['cell_type'] == 'raw' or cell['cell_type'] == 'raw') and len(cell['attachments']) == 0:
+            if cell['cell_type'] in ["raw", "markdown"] and not cell["attachments"]:
                 del cell['attachments']
 
         return dict(
@@ -141,15 +141,13 @@ class YNotebook(YBaseDoc):
                 if 'metadata' in cell :
                     metadata = cell["metadata"]
                 cell["metadata"] = Y.YMap(metadata)
-                if cell_type == 'raw' or cell_type == 'markdown':
+                if cell_type in ["raw", "markdown"]:
                     attachments = {}
                     if 'attachments' in cell:
                         attachments = cell["attachments"]
                     cell["attachments"] = Y.YMap(attachments)
-                if cell_type == 'code':
-                    outputs = []
-                    if 'outputs' in cell:
-                        outputs = cell["outputs"]
+                elif cell_type == "code":
+                    outputs = cell.get("outputs", [])
                     cell["outputs"] = Y.YArray(outputs)
                 ycell = Y.YMap(cell)
                 ycells.append(ycell)

--- a/jupyter_ydoc/ydoc.py
+++ b/jupyter_ydoc/ydoc.py
@@ -1,5 +1,4 @@
 import copy
-from importlib.metadata import metadata
 from uuid import uuid4
 
 import y_py as Y
@@ -55,7 +54,6 @@ class YFile(YBaseDoc):
 
     @property
     def source(self):
-        print(str(self._ysource))
         return str(self._ysource)
 
     @source.setter
@@ -139,33 +137,27 @@ class YNotebook(YBaseDoc):
                     cell["id"] = str(uuid4())
                 cell_type = cell["cell_type"]
                 cell["source"] = Y.YText(cell["source"])
-                
                 metadata = {}
                 if 'metadata' in cell :
                     metadata = cell["metadata"]
                 cell["metadata"] = Y.YMap(metadata)
-
                 if cell_type == 'raw' or cell_type == 'markdown':
                     attachments = {}
                     if 'attachments' in cell:
                         attachments = cell["attachments"]
                     cell["attachments"] = Y.YMap(attachments)
-
                 if cell_type == 'code':
                     outputs = []
                     if 'outputs' in cell:
                         outputs = cell["outputs"]
                     cell["outputs"] = Y.YArray(outputs)
-                
                 ycell = Y.YMap(cell)
                 ycells.append(ycell)
 
             if ycells:
                 self._ycells.extend(t, ycells)
-
             for k,v in nb["metadata"].items():
                 self._ymetadata.set(t, k, v)
-
             self._ymeta.set(t, "nbformat", nb["nbformat"])
             self._ymeta.set(t, "nbformat_minor", nb["nbformat_minor"])
 

--- a/jupyter_ydoc/ydoc.py
+++ b/jupyter_ydoc/ydoc.py
@@ -92,8 +92,8 @@ class YNotebook(YBaseDoc):
             if "id" in cell and meta["nbformat"] == 4 and meta["nbformat_minor"] <= 4:
                 # strip cell IDs if we have notebook format 4.0-4.4
                 del cell["id"]
-            if cell['cell_type'] in ["raw", "markdown"] and not cell["attachments"]:
-                del cell['attachments']
+            if cell["cell_type"] in ["raw", "markdown"] and not cell["attachments"]:
+                del cell["attachments"]
 
         return dict(
             cells=cells,
@@ -138,12 +138,12 @@ class YNotebook(YBaseDoc):
                 cell_type = cell["cell_type"]
                 cell["source"] = Y.YText(cell["source"])
                 metadata = {}
-                if 'metadata' in cell :
+                if "metadata" in cell:
                     metadata = cell["metadata"]
                 cell["metadata"] = Y.YMap(metadata)
                 if cell_type in ["raw", "markdown"]:
                     attachments = {}
-                    if 'attachments' in cell:
+                    if "attachments" in cell:
                         attachments = cell["attachments"]
                     cell["attachments"] = Y.YMap(attachments)
                 elif cell_type == "code":
@@ -154,7 +154,7 @@ class YNotebook(YBaseDoc):
 
             if ycells:
                 self._ycells.extend(t, ycells)
-            for k,v in nb["metadata"].items():
+            for k, v in nb["metadata"].items():
                 self._ymetadata.set(t, k, v)
             self._ymeta.set(t, "nbformat", nb["nbformat"])
             self._ymeta.set(t, "nbformat_minor", nb["nbformat_minor"])


### PR DESCRIPTION
This PR adds a new YMap for the metadata, to have the metadata as a Map instead of a JSONObject. This way when listening for changes we know what attribute changed. This schema is necessary for https://github.com/jupyterlab/jupyterlab/pull/12359.

I kept `ymeta` to store other metadata from the notebook that's not part of the metadata object, like `nbformat` and `nbformat_minor`.

This PR also improves the initialization of the cells by adding the outputs and attachments to the corresponding cells.