### PR TITLE
Handle missing attachment key

### DIFF
--- a/jupyter_ydoc/ydoc.py
+++ b/jupyter_ydoc/ydoc.py
@@ -90,7 +90,11 @@ class YNotebook(YBaseDoc):
         if "id" in cell and meta["nbformat"] == 4 and meta["nbformat_minor"] <= 4:
             # strip cell IDs if we have notebook format 4.0-4.4
             del cell["id"]
-        if "attachments" in cell and cell["cell_type"] in ["raw", "markdown"] and not cell["attachments"]:
+        if (
+            "attachments" in cell
+            and cell["cell_type"] in ["raw", "markdown"]
+            and not cell["attachments"]
+        ):
             del cell["attachments"]
         return cell
 
@@ -137,7 +141,11 @@ class YNotebook(YBaseDoc):
             if "id" in cell and meta["nbformat"] == 4 and meta["nbformat_minor"] <= 4:
                 # strip cell IDs if we have notebook format 4.0-4.4
                 del cell["id"]
-            if "attachments" in cell and cell["cell_type"] in ["raw", "markdown"] and not cell["attachments"]:
+            if (
+                "attachments" in cell
+                and cell["cell_type"] in ["raw", "markdown"]
+                and not cell["attachments"]
+            ):
                 del cell["attachments"]
             cells.append(cell)
 

--- a/jupyter_ydoc/ydoc.py
+++ b/jupyter_ydoc/ydoc.py
@@ -90,7 +90,7 @@ class YNotebook(YBaseDoc):
         if "id" in cell and meta["nbformat"] == 4 and meta["nbformat_minor"] <= 4:
             # strip cell IDs if we have notebook format 4.0-4.4
             del cell["id"]
-        if cell["cell_type"] in ["raw", "markdown"] and not cell["attachments"]:
+        if "attachments" in cell and cell["cell_type"] in ["raw", "markdown"] and not cell["attachments"]:
             del cell["attachments"]
         return cell
 
@@ -137,7 +137,7 @@ class YNotebook(YBaseDoc):
             if "id" in cell and meta["nbformat"] == 4 and meta["nbformat_minor"] <= 4:
                 # strip cell IDs if we have notebook format 4.0-4.4
                 del cell["id"]
-            if cell["cell_type"] in ["raw", "markdown"] and not cell["attachments"]:
+            if "attachments" in cell and cell["cell_type"] in ["raw", "markdown"] and not cell["attachments"]:
                 del cell["attachments"]
             cells.append(cell)
 


### PR DESCRIPTION
Fixes this error when opening [`OutputExamples.ipynb`](https://github.com/jupyterlab/jupyterlab/blob/master/examples/notebooks/OutputExamples.ipynb).

```
 File "/Users/jimgoo/miniconda3/envs/jlab-fork/lib/python3.8/site-packages/jupyter_server_ydoc/ydoc.py", line 249, in maybe_save_document
    if model["content"] != self.room.document.source:
  File "/Users/jimgoo/miniconda3/envs/jlab-fork/lib/python3.8/site-packages/jupyter_ydoc/ydoc.py", line 26, in source
    return self.get()
  File "/Users/jimgoo/miniconda3/envs/jlab-fork/lib/python3.8/site-packages/jupyter_ydoc/ydoc.py", line 140, in get
    if cell["cell_type"] in ["raw", "markdown"] and not cell["attachments"]:
KeyError: 'attachments'
```