### PR TITLE
Rename JS package to `@jupyter/ydoc`

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@jupyter-notebook/ydoc",
+  "name": "@jupyter/ydoc",
   "version": "0.3.0-alpha.1",
   "type": "module",
   "description": "Jupyter document structures for collaborative editing using YJS",

--- a/javascript/test/ymodels.spec.ts
+++ b/javascript/test/ymodels.spec.ts
@@ -3,7 +3,7 @@
 
 import { IMapChange, NotebookChange, YCodeCell, YNotebook } from '../src';
 
-describe('@jupyter-notebook/ydoc', () => {
+describe('@jupyter/ydoc', () => {
   describe('YNotebook', () => {
     describe('#constructor', () => {
       test('should create a notebook without arguments', () => {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@jupyter-notebook/ydoc-top-repo",
+  "name": "@jupyter/ydoc-top-repo",
   "version": "0.0.1",
   "private": true,
   "files": [],

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "dependencies": {
-    "@jupyter-notebook/ydoc": "file:../javascript",
+    "@jupyter/ydoc": "file:../javascript",
     "ws": "^8.5.0",
     "y-websocket": "^1.4.1"
   }

--- a/tests/yjs_client_0.js
+++ b/tests/yjs_client_0.js
@@ -1,4 +1,4 @@
-import { YNotebook } from '@jupyter-notebook/ydoc'
+import { YNotebook } from '@jupyter/ydoc'
 import { WebsocketProvider } from 'y-websocket'
 
 const notebook = new YNotebook()


### PR DESCRIPTION
Follow-up to https://github.com/jupyter-server/jupyter_ydoc/pull/86

This was discussed elsewhere on the JupyterLab repo.

Now that some of us managed to get a hold on the `@jupyter` scope on npm, it could interesting to rename this package to `@jupyter/ydoc` for consistency and early enough before it gets used more downstream.

cc @fcollonval 