### PR TITLE
add shortcut test case

### DIFF
--- a/tests/test_ypy_yjs.py
+++ b/tests/test_ypy_yjs.py
@@ -66,3 +66,10 @@ def test_plotly_renderer():
     nb = stringify_source(json.loads((files_dir / "plotly_renderer.ipynb").read_text()))
     ynotebook.source = nb
     assert ynotebook.source == nb
+
+
+def test_shortcut():
+    from jupyter_ydoc import ydocs
+    assert ydocs
+    assert ydocs['file']
+    assert ydocs['notebook']

--- a/tests/test_ypy_yjs.py
+++ b/tests/test_ypy_yjs.py
@@ -70,6 +70,7 @@ def test_plotly_renderer():
 
 def test_shortcut():
     from jupyter_ydoc import ydocs
+
     assert ydocs
-    assert ydocs['file']
-    assert ydocs['notebook']
+    assert ydocs["file"]
+    assert ydocs["notebook"]


### PR DESCRIPTION
shortcut does not seem to work on python 3.8

The `if` here does not seem to be used https://github.com/jupyter-server/jupyter_ydoc/blob/main/jupyter_ydoc/__init__.py#L8

