### PR TITLE
Make `YDocument` a `IObservableDisposable`

### DIFF
--- a/javascript/src/api.ts
+++ b/javascript/src/api.ts
@@ -20,7 +20,7 @@ import type {
   JSONValue,
   PartialJSONValue
 } from '@lumino/coreutils';
-import type { IDisposable, IObservableDisposable } from '@lumino/disposable';
+import type { IObservableDisposable } from '@lumino/disposable';
 import type { ISignal } from '@lumino/signaling';
 
 /**
@@ -44,7 +44,7 @@ export type MapChanges = Map<
 /**
  * ISharedBase defines common operations that can be performed on any shared object.
  */
-export interface ISharedBase extends IDisposable {
+export interface ISharedBase extends IObservableDisposable {
   /**
    * Undo an operation.
    */
@@ -387,8 +387,7 @@ export namespace SharedCell {
  */
 export interface ISharedBaseCell<
   Metadata extends nbformat.IBaseCellMetadata = nbformat.IBaseCellMetadata
-> extends ISharedText,
-    IObservableDisposable {
+> extends ISharedText {
   /**
    * The type of the cell.
    */

--- a/javascript/src/ymodels.ts
+++ b/javascript/src/ymodels.ts
@@ -93,6 +93,13 @@ export class YDocument<T extends DocumentChange> implements ISharedDocument {
   }
 
   /**
+   * A signal emitted when the document is disposed.
+   */
+  get disposed(): ISignal<this, void> {
+    return this._disposed;
+  }
+
+  /**
    * Whether the document is disposed or not.
    */
   get isDisposed(): boolean {
@@ -132,6 +139,7 @@ export class YDocument<T extends DocumentChange> implements ISharedDocument {
     this.awareness.destroy();
     this.undoManager.destroy();
     this.ydoc.destroy();
+    this._disposed.emit();
     Signal.clearData(this);
   }
 
@@ -209,6 +217,7 @@ export class YDocument<T extends DocumentChange> implements ISharedDocument {
 
   protected _changed = new Signal<this, T>(this);
   private _isDisposed = false;
+  private _disposed = new Signal<this, void>(this);
 }
 
 /**

--- a/javascript/test/ymodels.spec.ts
+++ b/javascript/test/ymodels.spec.ts
@@ -13,6 +13,18 @@ describe('@jupyter/ydoc', () => {
       });
     });
 
+    describe('#disposed', () => {
+      test('should be emitted when the document is disposed', () => {
+        const notebook = new YNotebook();
+        let disposed = false;
+        notebook.disposed.connect(() => {
+          disposed = true;
+        });
+        notebook.dispose();
+        expect(disposed).toEqual(true);
+      });
+    });
+
     describe('metadata', () => {
       test('should get metadata', () => {
         const notebook = new YNotebook();


### PR DESCRIPTION
Make the document disposal observable. This allows to trigger additional clearing actions.