### PR TITLE
Fixes multiple bugs

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -58,7 +58,8 @@
         "prettier": "^2.6.0",
         "rimraf": "^3.0.0",
         "typedoc": "^0.23.21",
-        "typescript": "^4.8.0"
+        "typescript": "^4.8.0",
+        "process": "0.11.10"
     },
     "publishConfig": {
         "access": "public"

--- a/javascript/src/api.ts
+++ b/javascript/src/api.ts
@@ -388,9 +388,9 @@ export namespace ISharedNotebook {
     disableDocumentWideUndoRedo?: boolean;
 
     /**
-     * The language preference for the model.
+     * The content of the notebook.
      */
-    languagePreference?: string;
+    data?: Partial<nbformat.INotebookContent>;
   }
 }
 

--- a/javascript/src/ycell.ts
+++ b/javascript/src/ycell.ts
@@ -18,8 +18,8 @@ import type {
   ISharedRawCell,
   SharedCell
 } from './api.js';
-import { IYText } from './ytext';
-import { YNotebook } from './ynotebook';
+import { IYText } from './ytext.js';
+import { YNotebook } from './ynotebook.js';
 
 /**
  * Cell type.
@@ -606,12 +606,21 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
             });
             break;
           case 'update':
-            if (!JSONExt.deepEqual(change.oldValue, this._ymetadata.get(key))) {
+            const newValue = this._ymetadata.get(key);
+            const oldValue = change.oldValue;
+            let equal = true;
+            if (typeof oldValue == 'object' && typeof newValue == 'object') {
+              equal = JSONExt.deepEqual(oldValue, newValue);
+            } else {
+              equal = oldValue == newValue;
+            }
+
+            if (!equal) {
               this._metadataChanged.emit({
                 key,
-                newValue: this._ymetadata.get(key),
-                oldValue: change.oldValue,
-                type: 'change'
+                type: 'change',
+                oldValue,
+                newValue
               });
             }
             break;

--- a/javascript/src/ycell.ts
+++ b/javascript/src/ycell.ts
@@ -612,7 +612,7 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
             if (typeof oldValue == 'object' && typeof newValue == 'object') {
               equal = JSONExt.deepEqual(oldValue, newValue);
             } else {
-              equal = oldValue == newValue;
+              equal = oldValue === newValue;
             }
 
             if (!equal) {

--- a/javascript/src/yfile.ts
+++ b/javascript/src/yfile.ts
@@ -5,8 +5,8 @@
 
 import * as Y from 'yjs';
 import type { Delta, FileChange, ISharedFile, ISharedText } from './api.js';
-import { IYText } from './ytext';
-import { YDocument } from './ydocument';
+import { IYText } from './ytext.js';
+import { YDocument } from './ydocument.js';
 
 /**
  * Shareable text file.

--- a/javascript/src/ynotebook.ts
+++ b/javascript/src/ynotebook.ts
@@ -490,7 +490,7 @@ export class YNotebook
             if (typeof oldValue == 'object' && typeof newValue == 'object') {
               equal = JSONExt.deepEqual(oldValue, newValue);
             } else {
-              equal = oldValue == newValue;
+              equal = oldValue === newValue;
             }
 
             if (!equal) {

--- a/javascript/src/ynotebook.ts
+++ b/javascript/src/ynotebook.ts
@@ -16,13 +16,13 @@ import type {
   SharedCell
 } from './api.js';
 
-import { YDocument } from './ydocument';
+import { YDocument } from './ydocument.js';
 import {
   createCell,
   createCellModelFromSharedType,
   YBaseCell,
   YCellType
-} from './ycell';
+} from './ycell.js';
 
 /**
  * Shared implementation of the Shared Document types.
@@ -46,7 +46,7 @@ export class YNotebook
    *
    * @param options
    */
-  constructor(options: ISharedNotebook.IOptions = {}) {
+  constructor(options: Omit<ISharedNotebook.IOptions, 'data'> = {}) {
     super();
     this._disableDocumentWideUndoRedo =
       options.disableDocumentWideUndoRedo ?? false;
@@ -75,14 +75,15 @@ export class YNotebook
     const ynotebook = new YNotebook({
       disableDocumentWideUndoRedo: options.disableDocumentWideUndoRedo ?? false
     });
-    const ymetadata = new Y.Map();
-    ymetadata.set('language_info', { name: options.languagePreference ?? '' });
-    ymetadata.set('kernelspec', {
-      name: '',
-      display_name: ''
-    });
-    ynotebook.ymeta.set('metadata', ymetadata);
 
+    const data: nbformat.INotebookContent = {
+      cells: options.data?.cells ?? [],
+      nbformat: options.data?.nbformat ?? 4,
+      nbformat_minor: options.data?.nbformat_minor ?? 5,
+      metadata: options.data?.metadata ?? {}
+    };
+
+    ynotebook.fromJSON(data);
     return ynotebook;
   }
 
@@ -483,12 +484,21 @@ export class YNotebook
             });
             break;
           case 'update':
-            if (!JSONExt.deepEqual(change.oldValue, ymetadata.get(key))) {
+            const newValue = ymetadata.get(key);
+            const oldValue = change.oldValue;
+            let equal = true;
+            if (typeof oldValue == 'object' && typeof newValue == 'object') {
+              equal = JSONExt.deepEqual(oldValue, newValue);
+            } else {
+              equal = oldValue == newValue;
+            }
+
+            if (!equal) {
               this._metadataChanged.emit({
                 key,
                 type: 'change',
-                oldValue: change.oldValue,
-                newValue: ymetadata.get(key)
+                oldValue,
+                newValue
               });
             }
             break;

--- a/javascript/test/ycell.spec.ts
+++ b/javascript/test/ycell.spec.ts
@@ -1,0 +1,230 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { IMapChange, YCodeCell, YNotebook } from '../src';
+
+describe('@jupyter/ydoc', () => {
+  describe('YCell standalone', () => {
+    test('should set source', () => {
+      const codeCell = YCodeCell.create();
+      codeCell.setSource('test');
+      expect(codeCell.getSource()).toBe('test');
+      codeCell.dispose();
+    });
+
+    test('should update source', () => {
+      const codeCell = YCodeCell.create();
+      codeCell.setSource('test');
+      codeCell.updateSource(0, 0, 'hello');
+      expect(codeCell.getSource()).toBe('hellotest');
+      codeCell.dispose();
+    });
+
+    test('should get metadata', () => {
+      const cell = YCodeCell.create();
+      const metadata = {
+        collapsed: true,
+        editable: false,
+        name: 'cell-name'
+      };
+
+      cell.setMetadata(metadata);
+
+      expect(cell.metadata).toEqual({
+        ...metadata,
+        jupyter: { outputs_hidden: true }
+      });
+      cell.dispose();
+    });
+
+    test('should get all metadata', () => {
+      const cell = YCodeCell.create();
+      const metadata = {
+        jupyter: { outputs_hidden: true },
+        editable: false,
+        name: 'cell-name'
+      };
+
+      cell.setMetadata(metadata);
+
+      expect(cell.getMetadata()).toEqual({ ...metadata, collapsed: true });
+      cell.dispose();
+    });
+
+    test('should get one metadata', () => {
+      const cell = YCodeCell.create();
+      const metadata = {
+        collapsed: true,
+        editable: false,
+        name: 'cell-name'
+      };
+
+      cell.setMetadata(metadata);
+
+      expect(cell.getMetadata('editable')).toEqual(metadata.editable);
+      cell.dispose();
+    });
+
+    it.each([null, undefined, 1, true, 'string', { a: 1 }, [1, 2]])(
+      'should get single metadata %s',
+      value => {
+        const cell = YCodeCell.create();
+        const metadata = {
+          collapsed: true,
+          editable: false,
+          name: 'cell-name',
+          test: value
+        };
+
+        cell.setMetadata(metadata);
+
+        expect(cell.getMetadata('test')).toEqual(value);
+        cell.dispose();
+      }
+    );
+
+    test('should set one metadata', () => {
+      const cell = YCodeCell.create();
+      const metadata = {
+        collapsed: true,
+        editable: false,
+        name: 'cell-name'
+      };
+
+      cell.setMetadata(metadata);
+      cell.setMetadata('test', 'banana');
+
+      expect(cell.getMetadata('test')).toEqual('banana');
+      cell.dispose();
+    });
+
+    test('should emit all metadata changes', () => {
+      const notebook = YNotebook.create();
+
+      const metadata = {
+        collapsed: true,
+        editable: false,
+        name: 'cell-name'
+      };
+
+      const changes: IMapChange[] = [];
+      notebook.metadataChanged.connect((_, c) => {
+        changes.push(c);
+      });
+      notebook.metadata = metadata;
+
+      expect(changes).toHaveLength(3);
+      expect(changes).toEqual([
+        {
+          type: 'add',
+          key: 'collapsed',
+          newValue: metadata.collapsed,
+          oldValue: undefined
+        },
+        {
+          type: 'add',
+          key: 'editable',
+          newValue: metadata.editable,
+          oldValue: undefined
+        },
+        {
+          type: 'add',
+          key: 'name',
+          newValue: metadata.name,
+          oldValue: undefined
+        }
+      ]);
+
+      notebook.dispose();
+    });
+
+    test('should emit a add metadata change', () => {
+      const cell = YCodeCell.create();
+      const metadata = {
+        collapsed: true,
+        editable: false,
+        name: 'cell-name'
+      };
+      cell.metadata = metadata;
+
+      const changes: IMapChange[] = [];
+      cell.metadataChanged.connect((_, c) => {
+        changes.push(c);
+      });
+      cell.setMetadata('test', 'banana');
+
+      try {
+        expect(changes).toHaveLength(1);
+        expect(changes).toEqual([
+          { type: 'add', key: 'test', newValue: 'banana', oldValue: undefined }
+        ]);
+      } finally {
+        cell.dispose();
+      }
+    });
+
+    test('should emit a delete metadata change', () => {
+      const cell = YCodeCell.create();
+      const metadata = {
+        collapsed: true,
+        editable: false,
+        name: 'cell-name'
+      };
+      cell.metadata = metadata;
+
+      const changes: IMapChange[] = [];
+      cell.setMetadata('test', 'banana');
+
+      cell.metadataChanged.connect((_, c) => {
+        changes.push(c);
+      });
+      cell.deleteMetadata('test');
+
+      try {
+        expect(changes).toHaveLength(1);
+        expect(changes).toEqual([
+          {
+            type: 'remove',
+            key: 'test',
+            newValue: undefined,
+            oldValue: 'banana'
+          }
+        ]);
+      } finally {
+        cell.dispose();
+      }
+    });
+
+    test('should emit an update metadata change', () => {
+      const cell = YCodeCell.create();
+      const metadata = {
+        collapsed: true,
+        editable: false,
+        name: 'cell-name'
+      };
+      cell.metadata = metadata;
+
+      const changes: IMapChange[] = [];
+      cell.setMetadata('test', 'banana');
+
+      cell.metadataChanged.connect((_, c) => {
+        changes.push(c);
+      });
+      cell.setMetadata('test', 'orange');
+
+      try {
+        expect(changes).toHaveLength(1);
+        expect(changes).toEqual([
+          {
+            type: 'change',
+            key: 'test',
+            newValue: 'orange',
+            oldValue: 'banana'
+          }
+        ]);
+      } finally {
+        cell.dispose();
+      }
+    });
+  });
+});

--- a/javascript/test/yfile.spec.ts
+++ b/javascript/test/yfile.spec.ts
@@ -1,0 +1,131 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { Delta, YFile } from '../src';
+
+describe('@jupyter/ydoc', () => {
+  describe('YFile', () => {
+    describe('#constructor', () => {
+      test('should create a document without arguments', () => {
+        const file = new YFile();
+        expect(file.source.length).toBe(0);
+        file.dispose();
+      });
+    });
+
+    describe('#disposed', () => {
+      test('should be emitted when the document is disposed', () => {
+        const file = new YFile();
+        let disposed = false;
+        file.disposed.connect(() => {
+          disposed = true;
+        });
+        file.dispose();
+        expect(disposed).toEqual(true);
+      });
+    });
+
+    describe('source', () => {
+      test('should set source', () => {
+        const file = new YFile();
+
+        const source = "foo";
+        file.setSource(source);
+
+        expect(file.source).toEqual(source);
+        file.dispose();
+      });
+
+      test('should get source', () => {
+        const file = new YFile();
+
+        const source = "foo";
+        file.setSource(source);
+
+        expect(file.getSource()).toEqual(source);
+        file.dispose();
+      });
+
+      test('should update source', () => {
+        const file = new YFile();
+
+        const source = "fooo bar";
+        file.setSource(source);
+        expect(file.source).toBe(source);
+
+        file.updateSource(3, 5, "/");
+        expect(file.source).toBe("foo/bar");
+        file.dispose();
+      });
+
+      test('should emit an insert source change', () => {
+        const file = new YFile();
+        expect(file.source).toBe("");
+
+        const changes: Delta<string>[] = [];
+        file.changed.connect((_, c) => {
+          changes.push(c.sourceChange!);
+        });
+        const source = "foo";
+        file.setSource(source);
+
+        expect(changes).toHaveLength(1);
+        expect(changes).toEqual([
+          [{
+            insert: "foo"
+          }]
+        ]);
+
+        file.dispose();
+      });
+
+      test('should emit a delete source change', () => {
+        const file = new YFile();
+        const source = "foo";
+        file.setSource(source);
+        expect(file.source).toBe(source);
+
+        const changes: Delta<string>[] = [];
+        file.changed.connect((_, c) => {
+          changes.push(c.sourceChange!);
+        });
+        file.setSource("");
+
+        expect(changes).toHaveLength(1);
+        expect(changes).toEqual([
+          [{
+            delete: 3
+          }]
+        ]);
+
+        file.dispose();
+      });
+
+      test('should emit an update source change', () => {
+        const file = new YFile();
+        const source_1 = "foo";
+        file.setSource(source_1);
+        expect(file.source).toBe(source_1);
+
+        const changes: Delta<string>[] = [];
+        file.changed.connect((_, c) => {
+          changes.push(c.sourceChange!);
+        });
+        const source = "bar";
+        file.setSource(source);
+
+        expect(changes).toHaveLength(1);
+        expect(changes).toEqual([
+          [{
+            delete: 3
+          },
+          {
+            insert: source
+          },]
+        ]);
+
+        file.dispose();
+      });
+    });
+  });
+});

--- a/javascript/test/yfile.spec.ts
+++ b/javascript/test/yfile.spec.ts
@@ -29,7 +29,7 @@ describe('@jupyter/ydoc', () => {
       test('should set source', () => {
         const file = new YFile();
 
-        const source = "foo";
+        const source = 'foo';
         file.setSource(source);
 
         expect(file.source).toEqual(source);
@@ -39,7 +39,7 @@ describe('@jupyter/ydoc', () => {
       test('should get source', () => {
         const file = new YFile();
 
-        const source = "foo";
+        const source = 'foo';
         file.setSource(source);
 
         expect(file.getSource()).toEqual(source);
@@ -49,31 +49,33 @@ describe('@jupyter/ydoc', () => {
       test('should update source', () => {
         const file = new YFile();
 
-        const source = "fooo bar";
+        const source = 'fooo bar';
         file.setSource(source);
         expect(file.source).toBe(source);
 
-        file.updateSource(3, 5, "/");
-        expect(file.source).toBe("foo/bar");
+        file.updateSource(3, 5, '/');
+        expect(file.source).toBe('foo/bar');
         file.dispose();
       });
 
       test('should emit an insert source change', () => {
         const file = new YFile();
-        expect(file.source).toBe("");
+        expect(file.source).toBe('');
 
         const changes: Delta<string>[] = [];
         file.changed.connect((_, c) => {
           changes.push(c.sourceChange!);
         });
-        const source = "foo";
+        const source = 'foo';
         file.setSource(source);
 
         expect(changes).toHaveLength(1);
         expect(changes).toEqual([
-          [{
-            insert: "foo"
-          }]
+          [
+            {
+              insert: 'foo'
+            }
+          ]
         ]);
 
         file.dispose();
@@ -81,7 +83,7 @@ describe('@jupyter/ydoc', () => {
 
       test('should emit a delete source change', () => {
         const file = new YFile();
-        const source = "foo";
+        const source = 'foo';
         file.setSource(source);
         expect(file.source).toBe(source);
 
@@ -89,13 +91,15 @@ describe('@jupyter/ydoc', () => {
         file.changed.connect((_, c) => {
           changes.push(c.sourceChange!);
         });
-        file.setSource("");
+        file.setSource('');
 
         expect(changes).toHaveLength(1);
         expect(changes).toEqual([
-          [{
-            delete: 3
-          }]
+          [
+            {
+              delete: 3
+            }
+          ]
         ]);
 
         file.dispose();
@@ -103,25 +107,27 @@ describe('@jupyter/ydoc', () => {
 
       test('should emit an update source change', () => {
         const file = new YFile();
-        const source_1 = "foo";
-        file.setSource(source_1);
-        expect(file.source).toBe(source_1);
+        const source1 = 'foo';
+        file.setSource(source1);
+        expect(file.source).toBe(source1);
 
         const changes: Delta<string>[] = [];
         file.changed.connect((_, c) => {
           changes.push(c.sourceChange!);
         });
-        const source = "bar";
+        const source = 'bar';
         file.setSource(source);
 
         expect(changes).toHaveLength(1);
         expect(changes).toEqual([
-          [{
-            delete: 3
-          },
-          {
-            insert: source
-          },]
+          [
+            {
+              delete: 3
+            },
+            {
+              insert: source
+            }
+          ]
         ]);
 
         file.dispose();

--- a/javascript/test/ymodels.spec.ts
+++ b/javascript/test/ymodels.spec.ts
@@ -154,23 +154,17 @@ describe('@jupyter/ydoc', () => {
         });
         notebook.metadata = metadata;
 
-        expect(changes).toHaveLength(3);
+        expect(changes).toHaveLength(2);
         expect(changes).toEqual([
-          {
-            type: 'remove',
-            key: 'language_info',
-            oldValue: { name: '' }
-          },
-          {
-            type: 'change',
-            key: 'kernelspec',
-            newValue: metadata.kernelspec,
-            oldValue: { display_name: '', name: '' }
-          },
           {
             type: 'add',
             key: 'orig_nbformat',
             newValue: metadata.orig_nbformat
+          },
+          {
+            type: 'add',
+            key: 'kernelspec',
+            newValue: metadata.kernelspec
           }
         ]);
 
@@ -202,10 +196,9 @@ describe('@jupyter/ydoc', () => {
             newValue: metadata.orig_nbformat
           },
           {
-            type: 'change',
+            type: 'add',
             key: 'kernelspec',
-            newValue: metadata.kernelspec,
-            oldValue: { display_name: '', name: '' }
+            newValue: metadata.kernelspec
           }
         ]);
 
@@ -555,20 +548,8 @@ describe('@jupyter/ydoc', () => {
       });
       notebook.metadata = metadata;
 
-      expect(changes).toHaveLength(5);
+      expect(changes).toHaveLength(3);
       expect(changes).toEqual([
-        {
-          type: 'remove',
-          key: 'language_info',
-          newValue: undefined,
-          oldValue: { name: '' }
-        },
-        {
-          type: 'remove',
-          key: 'kernelspec',
-          newValue: undefined,
-          oldValue: { display_name: '', name: '' }
-        },
         {
           type: 'add',
           key: 'collapsed',

--- a/javascript/test/ynotebook.spec.ts
+++ b/javascript/test/ynotebook.spec.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { IMapChange, NotebookChange, YCodeCell, YNotebook } from '../src';
+import type * as nbformat from '@jupyterlab/nbformat';
+import { IMapChange, NotebookChange, YNotebook } from '../src';
 
 describe('@jupyter/ydoc', () => {
   describe('YNotebook', () => {
@@ -9,6 +10,50 @@ describe('@jupyter/ydoc', () => {
       test('should create a notebook without arguments', () => {
         const notebook = YNotebook.create();
         expect(notebook.cells.length).toBe(0);
+        notebook.dispose();
+      });
+    });
+
+    describe('#factory', () => {
+      test('should create a notebook with a cell', () => {
+        const cell: nbformat.ICodeCell = {
+          id: 'first-cell',
+          cell_type: 'code',
+          source: '',
+          metadata: {},
+          outputs: [],
+          execution_count: null
+        };
+
+        const notebook = YNotebook.create({
+          data: {
+            cells: [cell]
+          }
+        });
+        expect(notebook.cells).toHaveLength(1);
+        expect(notebook.cells[0].toJSON()).toEqual(cell);
+        notebook.dispose();
+      });
+
+      test('should create a notebook with metadata', () => {
+        const metadata: nbformat.INotebookMetadata = {
+          kernelspec: {
+            name: "xeus-python",
+            display_name: "Xeus Python"
+          }
+        };
+
+        const notebook = YNotebook.create({
+          data: {
+            nbformat: 1,
+            nbformat_minor: 0,
+            metadata
+          }
+        });
+        expect(notebook.cells).toHaveLength(0);
+        expect(notebook.nbformat).toEqual(1);
+        expect(notebook.nbformat_minor).toEqual(0);
+        expect(notebook.metadata).toEqual(metadata);
         notebook.dispose();
       });
     });
@@ -436,230 +481,6 @@ describe('@jupyter/ydoc', () => {
         expect(notebook.cells[0].id).not.toEqual('first-cell');
         notebook.dispose();
       });
-    });
-  });
-
-  describe('YCell standalone', () => {
-    test('should set source', () => {
-      const codeCell = YCodeCell.create();
-      codeCell.setSource('test');
-      expect(codeCell.getSource()).toBe('test');
-      codeCell.dispose();
-    });
-
-    test('should update source', () => {
-      const codeCell = YCodeCell.create();
-      codeCell.setSource('test');
-      codeCell.updateSource(0, 0, 'hello');
-      expect(codeCell.getSource()).toBe('hellotest');
-      codeCell.dispose();
-    });
-
-    test('should get metadata', () => {
-      const cell = YCodeCell.create();
-      const metadata = {
-        collapsed: true,
-        editable: false,
-        name: 'cell-name'
-      };
-
-      cell.setMetadata(metadata);
-
-      expect(cell.metadata).toEqual({
-        ...metadata,
-        jupyter: { outputs_hidden: true }
-      });
-      cell.dispose();
-    });
-
-    test('should get all metadata', () => {
-      const cell = YCodeCell.create();
-      const metadata = {
-        jupyter: { outputs_hidden: true },
-        editable: false,
-        name: 'cell-name'
-      };
-
-      cell.setMetadata(metadata);
-
-      expect(cell.getMetadata()).toEqual({ ...metadata, collapsed: true });
-      cell.dispose();
-    });
-
-    test('should get one metadata', () => {
-      const cell = YCodeCell.create();
-      const metadata = {
-        collapsed: true,
-        editable: false,
-        name: 'cell-name'
-      };
-
-      cell.setMetadata(metadata);
-
-      expect(cell.getMetadata('editable')).toEqual(metadata.editable);
-      cell.dispose();
-    });
-
-    it.each([null, undefined, 1, true, 'string', { a: 1 }, [1, 2]])(
-      'should get single metadata %s',
-      value => {
-        const cell = YCodeCell.create();
-        const metadata = {
-          collapsed: true,
-          editable: false,
-          name: 'cell-name',
-          test: value
-        };
-
-        cell.setMetadata(metadata);
-
-        expect(cell.getMetadata('test')).toEqual(value);
-        cell.dispose();
-      }
-    );
-
-    test('should set one metadata', () => {
-      const cell = YCodeCell.create();
-      const metadata = {
-        collapsed: true,
-        editable: false,
-        name: 'cell-name'
-      };
-
-      cell.setMetadata(metadata);
-      cell.setMetadata('test', 'banana');
-
-      expect(cell.getMetadata('test')).toEqual('banana');
-      cell.dispose();
-    });
-
-    test('should emit all metadata changes', () => {
-      const notebook = YNotebook.create();
-
-      const metadata = {
-        collapsed: true,
-        editable: false,
-        name: 'cell-name'
-      };
-
-      const changes: IMapChange[] = [];
-      notebook.metadataChanged.connect((_, c) => {
-        changes.push(c);
-      });
-      notebook.metadata = metadata;
-
-      expect(changes).toHaveLength(3);
-      expect(changes).toEqual([
-        {
-          type: 'add',
-          key: 'collapsed',
-          newValue: metadata.collapsed,
-          oldValue: undefined
-        },
-        {
-          type: 'add',
-          key: 'editable',
-          newValue: metadata.editable,
-          oldValue: undefined
-        },
-        {
-          type: 'add',
-          key: 'name',
-          newValue: metadata.name,
-          oldValue: undefined
-        }
-      ]);
-
-      notebook.dispose();
-    });
-
-    test('should emit a add metadata change', () => {
-      const cell = YCodeCell.create();
-      const metadata = {
-        collapsed: true,
-        editable: false,
-        name: 'cell-name'
-      };
-      cell.metadata = metadata;
-
-      const changes: IMapChange[] = [];
-      cell.metadataChanged.connect((_, c) => {
-        changes.push(c);
-      });
-      cell.setMetadata('test', 'banana');
-
-      try {
-        expect(changes).toHaveLength(1);
-        expect(changes).toEqual([
-          { type: 'add', key: 'test', newValue: 'banana', oldValue: undefined }
-        ]);
-      } finally {
-        cell.dispose();
-      }
-    });
-
-    test('should emit a delete metadata change', () => {
-      const cell = YCodeCell.create();
-      const metadata = {
-        collapsed: true,
-        editable: false,
-        name: 'cell-name'
-      };
-      cell.metadata = metadata;
-
-      const changes: IMapChange[] = [];
-      cell.setMetadata('test', 'banana');
-
-      cell.metadataChanged.connect((_, c) => {
-        changes.push(c);
-      });
-      cell.deleteMetadata('test');
-
-      try {
-        expect(changes).toHaveLength(1);
-        expect(changes).toEqual([
-          {
-            type: 'remove',
-            key: 'test',
-            newValue: undefined,
-            oldValue: 'banana'
-          }
-        ]);
-      } finally {
-        cell.dispose();
-      }
-    });
-
-    test('should emit an update metadata change', () => {
-      const cell = YCodeCell.create();
-      const metadata = {
-        collapsed: true,
-        editable: false,
-        name: 'cell-name'
-      };
-      cell.metadata = metadata;
-
-      const changes: IMapChange[] = [];
-      cell.setMetadata('test', 'banana');
-
-      cell.metadataChanged.connect((_, c) => {
-        changes.push(c);
-      });
-      cell.setMetadata('test', 'orange');
-
-      try {
-        expect(changes).toHaveLength(1);
-        expect(changes).toEqual([
-          {
-            type: 'change',
-            key: 'test',
-            newValue: 'orange',
-            oldValue: 'banana'
-          }
-        ]);
-      } finally {
-        cell.dispose();
-      }
     });
   });
 });

--- a/javascript/test/ynotebook.spec.ts
+++ b/javascript/test/ynotebook.spec.ts
@@ -38,8 +38,8 @@ describe('@jupyter/ydoc', () => {
       test('should create a notebook with metadata', () => {
         const metadata: nbformat.INotebookMetadata = {
           kernelspec: {
-            name: "xeus-python",
-            display_name: "Xeus Python"
+            name: 'xeus-python',
+            display_name: 'Xeus Python'
           }
         };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -596,7 +596,7 @@
     "@jridgewell/sourcemap-codec" "1.4.14"
 
 "@jupyter/ydoc@file:javascript":
-  version "0.3.0-a4"
+  version "0.3.0-a5"
   dependencies:
     "@jupyterlab/nbformat" "^3.0.0 || ^4.0.0-alpha.15"
     "@lumino/coreutils" "^1.11.0 || ^2.0.0-alpha.6"
@@ -5501,6 +5501,11 @@ process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
+
+process@0.11.10:
+  version "0.11.10"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
+  integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
 
 promise-all-reject-late@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Necessary to fix tests in JupyterLab.

# Code changes:
* Dependency process: When linking `@jupyter/ydoc` to jupyterlab in dev mode, JupyterLab complains about ydoc missing this dependency. I added it in devDependencies so we only install it in dev mode.
* I changed the argument of the static method `YNotebook.create` to be able to initialize the notebook in a generic way. For example, JupyterLab needs to initialize the model with `nbformat`, `nbformat_minor`, and `metadata` but other frontends might need other attributes.
* Fixed the imports
* Fixed the callbacks for metadata changed in YCell and YNotebook. Both `oldValue` and `newValue` might be `undefined`.