### PR TITLE
Remove factory API

### DIFF
--- a/docs/source/custom.md
+++ b/docs/source/custom.md
@@ -17,4 +17,4 @@ On the other side, to export a back-end model, we have to use the entry points p
 my_document = "my_module.my_file:YCustomDocument"
 ```
 
-You can find an example of a custom document in the [JupyterCAD extension](https://github.com/QuantStack/jupytercad). With an implementation of a new document model [here](https://github.com/QuantStack/jupytercad/blob/main/jupytercad/jcad_ydoc.py) and registering it [here](https://github.com/QuantStack/jupytercad/blob/main/setup.cfg).
+You can find an example of a custom document in the [JupyterCAD extension](https://github.com/QuantStack/jupytercad). With an implementation of a new document model [here](https://github.com/QuantStack/jupytercad/blob/main/jupytercad/jcad_ydoc.py) and registering it [here](https://github.com/QuantStack/jupytercad/blob/main/pyproject.toml).

--- a/javascript/src/api.ts
+++ b/javascript/src/api.ts
@@ -42,47 +42,6 @@ export type MapChanges = Map<
 >;
 
 /**
- * A factory interface for creating `ISharedDocument` objects.
- */
-export interface IFactory {
-  /**
-   * Create a new `ISharedDocument` instance.
-   *
-   * It should return `undefined` if the factory is not able to create a `ISharedDocument`.
-   */
-  createNew(options: IFactory.IOptions): ISharedDocument | undefined;
-}
-
-/**
- * The namespace for `IFactory`.
- */
-export namespace IFactory {
-  /**
-   * The options used to instantiate a ISharedDocument
-   */
-  export interface IOptions {
-    /**
-     * The path of the file.
-     */
-    path: string;
-    /**
-     * The format of the document.
-     */
-    format: string;
-    /**
-     * The content type of the document.
-     */
-    contentType: string;
-    /**
-     * Wether the document is collaborative or not.
-     *
-     *  The default value is `true`.
-     */
-    collaborative?: boolean;
-  }
-}
-
-/**
  * ISharedBase defines common operations that can be performed on any shared object.
  */
 export interface ISharedBase extends IObservableDisposable {


### PR DESCRIPTION
As the consumer of the factory API is in JupyterLab, it makes more sense to place the interface there.

cc @fcollonval 