### PR TITLE
Fixes handling metadata changes

### DIFF
--- a/javascript/src/ynotebook.ts
+++ b/javascript/src/ynotebook.ts
@@ -12,6 +12,7 @@ import type {
   IMapChange,
   ISharedCell,
   ISharedNotebook,
+  MapChanges,
   NotebookChange,
   SharedCell
 } from './api.js';
@@ -514,6 +515,26 @@ export class YNotebook
 
     if (!metaEvent) {
       return;
+    }
+
+    if (metaEvent.keysChanged.has('metadata')) {
+      // Handle metadata change when adding/removing the YMap
+      const change = metaEvent.changes.keys.get('metadata');
+      if (change?.action === 'add' && !change.oldValue) {
+        const metadataChange: MapChanges = new Map<string, any>();
+        for (const key of Object.keys(this.metadata)) {
+          metadataChange.set(key, {
+            action: 'add',
+            oldValue: undefined
+          });
+          this._metadataChanged.emit({
+            key,
+            type: 'add',
+            newValue: this.getMetadata(key)
+          });
+        }
+        this._changed.emit({ metadataChange });
+      }
     }
 
     if (metaEvent.keysChanged.has('nbformat')) {


### PR DESCRIPTION
When setting the YMap for the metadata attribute, we do not emit an event.

We were not emitting the events for actions like:
* `this.ymeta.set('metadata', new Y.Map())`
* `this.ymeta.delete('metadata')`