### PR TITLE
Fix metadata issue

### DIFF
--- a/jupyter_ydoc/ynotebook.py
+++ b/jupyter_ydoc/ynotebook.py
@@ -203,7 +203,6 @@ class YNotebook(YBaseDoc):
         :rtype: Dict
         """
         meta = json.loads(self._ymeta.to_json())
-        print("[YNotebook.get] meta:", meta)
         cast_all(meta, float, int)  # notebook coming from Yjs has e.g. nbformat as float
         cells = []
         for i in range(len(self._ycells)):

--- a/jupyter_ydoc/ynotebook.py
+++ b/jupyter_ydoc/ynotebook.py
@@ -203,6 +203,7 @@ class YNotebook(YBaseDoc):
         :rtype: Dict
         """
         meta = json.loads(self._ymeta.to_json())
+        print("[YNotebook.get] meta:", meta)
         cast_all(meta, float, int)  # notebook coming from Yjs has e.g. nbformat as float
         cells = []
         for i in range(len(self._ycells)):
@@ -220,9 +221,9 @@ class YNotebook(YBaseDoc):
 
         return dict(
             cells=cells,
-            metadata=meta["metadata"],
-            nbformat=int(meta["nbformat"]),
-            nbformat_minor=int(meta["nbformat_minor"]),
+            metadata=meta.get("metadata", {}),
+            nbformat=int(meta.get("nbformat", 0)),
+            nbformat_minor=int(meta.get("nbformat_minor", 0)),
         )
 
     def set(self, value: Dict) -> None:


### PR DESCRIPTION
When the YNotebook is empty, if we try to get the content, it will raise an exception because the 'metadata' key doesn't exist.

This PR fixes the issue.