### PR TITLE
Trust the default cell

### DIFF
--- a/jupyter_ydoc/ynotebook.py
+++ b/jupyter_ydoc/ynotebook.py
@@ -239,7 +239,8 @@ class YNotebook(YBaseDoc):
             {
                 "cell_type": "code",
                 "execution_count": None,
-                "metadata": {},
+                # auto-created empty code cell without outputs ought be trusted
+                "metadata": {"trusted": True},
                 "outputs": [],
                 "source": "",
                 "id": str(uuid4()),


### PR DESCRIPTION
Empty cells should be trusted by default. This accompanies a larger work in JupyterLab (https://github.com/jupyterlab/jupyterlab/pull/14345) aimed at preserving trust behaviour of classing notebook (https://github.com/jupyterlab/jupyterlab/issues/14025).

An alternative (as discussed in the linked PR) is to always add `trusted: true` metadata to code cells which do not have any outputs (which could be implemented in `sharedModel.insertCell`) with the pros/cons:
- (+) less repetitive
- (+) harder to forget about trust downstream
- (-) less secure in case if the output gets populated immediately after cell creation (e.g. by unaware extension developer) with result not controlled by the user

Given that security implications I am proposing the more conservative approach of doing it manually each time for now, but I think we could as well automate this in the future (with a big disclaimer in extension upgrade guide).