### PR TITLE
Bump y-py to 0.6.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ from jupyter_ydoc import YFile, YNotebook
 The `"jupyter_ydoc"` entry point group can be populated with your own documents, e.g. by adding the
 following to your package's `setup.cfg`:
 
-```
+```ini
 [options.entry_points]
 jupyter_ydoc =
     my_document = my_package.my_file:MyDocumentClass

--- a/jupyter_ydoc/__init__.py
+++ b/jupyter_ydoc/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 import sys
 
 from ._version import __version__  # noqa

--- a/jupyter_ydoc/utils.py
+++ b/jupyter_ydoc/utils.py
@@ -1,3 +1,6 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 from typing import Dict, List, Type, Union
 
 INT = Type[int]

--- a/jupyter_ydoc/ydoc.py
+++ b/jupyter_ydoc/ydoc.py
@@ -1,4 +1,8 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 import copy
+import json
 from typing import Any, Dict
 from uuid import uuid4
 
@@ -93,8 +97,8 @@ class YNotebook(YBaseDoc):
         self._ycells = self._ydoc.get_array("cells")
 
     def get_cell(self, index: int) -> Dict[str, Any]:
-        meta = self._ymeta.to_json()
-        cell = self._ycells[index].to_json()
+        meta = json.loads(self._ymeta.to_json())
+        cell = json.loads(self._ycells[index].to_json())
         cast_all(cell, float, int)  # cells coming from Yjs have e.g. execution_count as float
         if "id" in cell and meta["nbformat"] == 4 and meta["nbformat_minor"] <= 4:
             # strip cell IDs if we have notebook format 4.0-4.4
@@ -145,7 +149,7 @@ class YNotebook(YBaseDoc):
             self._ycells.insert(txn, index, ycell)
 
     def get(self):
-        meta = self._ymeta.to_json()
+        meta = json.loads(self._ymeta.to_json())
         cast_all(meta, float, int)  # notebook coming from Yjs has e.g. nbformat as float
         cells = []
         for i in range(len(self._ycells)):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.7"
 keywords = ["jupyter", "ypy"]
 dependencies = [
     "importlib_metadata >=3.6; python_version<\"3.10\"",
-    "y-py >=0.5.3,<0.6.0",
+    "y-py >=0.6.0,<0.7.0",
 ]
 
 [[project.authors]]
@@ -23,7 +23,7 @@ test = [
     "pytest",
     "pytest-asyncio",
     "websockets >=10.0",
-    "ypy-websocket >=0.3.1,<0.4.0",
+    "ypy-websocket >=0.8.4,<0.9.0",
 ]
 dev = [
     "click",


### PR DESCRIPTION
## Reference

Fixes https://github.com/jupyterlab/jupyterlab/issues/14764

## Changes

- Bump y-py to ~0.6.0
- Wrap `to_json` with `json.loads`

- Add license header on Python files