### PR TITLE
Add source to dist for sourcemaps

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -19,7 +19,8 @@
         "lib": "lib/"
     },
     "files": [
-        "lib/**/*.{d.ts,js,js.map,json}"
+        "lib/**/*.{d.ts,js,js.map,json}",
+        "src/**/*.{ts}"
     ],
     "scripts": {
         "build": "tsc -b",


### PR DESCRIPTION
We currently generate and distribute source maps, but not the source that the sourcemaps point to. As exemplified by this warning:

```
WARNING in ../../node_modules/@jupyter/ydoc/lib/ytext.js
Module Warning (from ./node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '<root>\node_modules\@jupyter\ydoc\src\ytext.ts' file: Error: ENOENT: no such file or directory, open '<root>\node_modules\@jupyter\ydoc\src\ytext.ts'
```

This change will include the source files in the package dist.