### PR TITLE
Fix joining of `source` when `source` is an array of strings

### DIFF
--- a/javascript/src/ycell.ts
+++ b/javascript/src/ycell.ts
@@ -113,7 +113,7 @@ export const createCell = (
   }
   if (cell.source != null) {
     ycell.setSource(
-      typeof cell.source === 'string' ? cell.source : cell.source.join('\n')
+      typeof cell.source === 'string' ? cell.source : cell.source.join('')
     );
   }
   return ycell;

--- a/javascript/test/ycell.spec.ts
+++ b/javascript/test/ycell.spec.ts
@@ -2,7 +2,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { IMapChange, YCodeCell, YNotebook } from '../src';
+import { createStandaloneCell, IMapChange, YCodeCell, YNotebook } from '../src';
 
 describe('@jupyter/ydoc', () => {
   // Fix awareness timeout open handle
@@ -11,6 +11,17 @@ describe('@jupyter/ydoc', () => {
   });
   afterEach(() => {
     jest.clearAllTimers();
+  });
+
+  describe('createStandaloneCell', () => {
+    test('should convert a source set as a list of string to a single string', () => {
+      const cell = createStandaloneCell({
+        cell_type: 'code',
+        source: ['import this\n', 'import math']
+      });
+
+      expect(cell.source).toEqual('import this\nimport math');
+    });
   });
 
   describe('YCell standalone', () => {


### PR DESCRIPTION
This *should* fix the issue noticed in https://github.com/jupyterlite/jupyterlite/issues/1141#issuecomment-1733613297.

As discussed in https://github.com/jupyterlite/jupyterlite/issues/1141#issuecomment-1733613297, loading notebooks which have cells with their `source` set to be a list of strings instead of a single string.

Example notebook: https://github.com/jupyterlite/jupyterlite/blob/main/examples/pyodide/ipycanvas.ipynb

Example cell:

```json
{
   "cell_type": "code",
   "execution_count": null,
   "metadata": {},
   "outputs": [],
   "source": [
    "def life_step(x):\n",
    "    \"\"\"Game of life step\"\"\"\n",
    "    nbrs_count = sum(\n",
    "        np.roll(np.roll(x, i, 0), j, 1)\n",
    "        for i in (-1, 0, 1)\n",
    "        for j in (-1, 0, 1)\n",
    "        if (i != 0 or j != 0)\n",
    "    )\n",
    "    return (nbrs_count == 3) | (x & (nbrs_count == 2))"
   ]
  },
```

Which in JupyterLite renders as follows with extra line breaks:

![image](https://github.com/jupyter-server/jupyter_ydoc/assets/591645/8fc0d9d9-f60b-47ea-bd5b-73f45a569414)


Currently the server component in JupyterLite does not normalize the `source` to be a string. So it sends the array of strings to the frontend.

---

This is not an issue in stock JupyterLab because the response from the Jupyter Server already normalizes the `source` to be a single string:

![image](https://github.com/jupyter-server/jupyter_ydoc/assets/591645/d9c4595a-60d1-40e9-bc5b-e555aba36dbc)

This is likely because Jupyter Server uses `nbformat` to read the notebook: https://github.com/jupyter-server/jupyter_server/blob/3544deb53902cc02c9aa9d6513b3c30f1113896b/jupyter_server/services/contents/fileio.py#L264-L291

And the `nbformat` documentation mentions the following in https://nbformat.readthedocs.io/en/latest/format_description.html#cell-types:

> On disk, multi-line strings MAY be split into lists of strings. When read with the nbformat Python API, these multi-line strings will always be a single string.

`nbformat` also joins the string with an empty string: https://github.com/jupyter/nbformat/blob/0a2942c8f77d33b43a327293c7a7596afcf4527d/nbformat/v4/rwbase.py#L38

```py
for cell in nb.cells:
    if "source" in cell and isinstance(cell.source, list):
        cell.source = "".join(cell.source)
```