### PR TITLE
Fix a typo in docs (wrong closing quote)

### DIFF
--- a/javascript/src/api.ts
+++ b/javascript/src/api.ts
@@ -145,7 +145,7 @@ export interface ISharedText extends ISharedBase {
   setSource(value: string): void;
 
   /**
-   * Replace content from `start' to `end` with `value`.
+   * Replace content from `start` to `end` with `value`.
    *
    * @param start: The start index of the range to replace (inclusive).
    * @param end: The end index of the range to replace (exclusive).


### PR DESCRIPTION
Improves rendering of the docs, previously:

![image](https://github.com/jupyter-server/jupyter_ydoc/assets/5832902/aa0c1c08-9b26-4c9a-982d-a6823a2f84a3)
