### PR TITLE
Bump notebook version 1.0.0 -> 2.0.0

### DIFF
--- a/javascript/src/ynotebook.ts
+++ b/javascript/src/ynotebook.ts
@@ -69,7 +69,7 @@ export class YNotebook
   /**
    * Document version
    */
-  readonly version: string = '1.0.0';
+  readonly version: string = '2.0.0';
 
   /**
    * Creates a standalone YNotebook

--- a/jupyter_ydoc/ynotebook.py
+++ b/jupyter_ydoc/ynotebook.py
@@ -65,7 +65,7 @@ class YNotebook(YBaseDoc):
         :return: Document's version.
         :rtype: str
         """
-        return "1.0.0"
+        return "2.0.0"
 
     @property
     def ycells(self):


### PR DESCRIPTION
The changes to the notebook structure made in #201 require a major version bump since they are backwards-incompatible.