### PR TITLE
Add optional origin to transaction, filter out 'modeldb' origin

### DIFF
--- a/javascript/src/api.ts
+++ b/javascript/src/api.ts
@@ -78,7 +78,7 @@ export interface ISharedBase extends IObservableDisposable {
    * @param f Transaction to execute
    * @param undoable Whether to track the change in the action history or not (default `true`)
    */
-  transact(f: () => void, undoable?: boolean): void;
+  transact(f: () => void, undoable?: boolean, origin?: any): void;
 }
 
 /**

--- a/javascript/src/ydocument.ts
+++ b/javascript/src/ydocument.ts
@@ -170,8 +170,8 @@ export abstract class YDocument<T extends DocumentChange>
    * Perform a transaction. While the function f is called, all changes to the shared
    * document are bundled into a single event.
    */
-  transact(f: () => void, undoable = true): void {
-    this.ydoc.transact(f, undoable ? this : null);
+  transact(f: () => void, undoable = true, origin: any = null): void {
+    this.ydoc.transact(f, undoable ? this : origin);
   }
 
   /**


### PR DESCRIPTION
In https://github.com/jupyterlab/jupyterlab/pull/16498 JupyterLab will handle cell outputs in a better way. Previously, the assumption was that only the frontend could modify a document (apart from the initial loading), but with server-side execution this is not true anymore. Thus changes to the Y model must be observed and modelDB must be changed accordingly. But in turns, changes to modelDB must also be applied to the Y model, so in order to break this circular dependency, we must use Yjs's [origins](https://beta.yjs.dev/docs/api/transactions/#the-origin-concept) to not apply a change initiated by modelDB to modelDB again.
In this PR, the origin that identifies a change from modelDB is the string `"modeldb"`. A change with this origin will not emit a change signal.