### PR TITLE
Add undo_manager to Y documents (#248)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [main]
+    branches: [2.x]
   pull_request:
-    branches: [main]
+    branches: [2.x]
 
 jobs:
   pre-commit:

--- a/jupyter_ydoc/yblob.py
+++ b/jupyter_ydoc/yblob.py
@@ -36,7 +36,8 @@ class YBlob(YBaseDoc):
         :type ydoc: :class:`pycrdt.Doc`, optional.
         """
         super().__init__(ydoc)
-        self._ydoc["source"] = self._ysource = Map()
+        self._ysource = self._ydoc.get("source", type=Map)
+        self.undo_manager.expand_scope(self._ysource)
 
     @property
     def version(self) -> str:

--- a/jupyter_ydoc/ynotebook.py
+++ b/jupyter_ydoc/ynotebook.py
@@ -54,8 +54,9 @@ class YNotebook(YBaseDoc):
         :type ydoc: :class:`pycrdt.Doc`, optional.
         """
         super().__init__(ydoc)
-        self._ydoc["meta"] = self._ymeta = Map()
-        self._ydoc["cells"] = self._ycells = Array()
+        self._ymeta = self._ydoc.get("meta", type=Map)
+        self._ycells = self._ydoc.get("cells", type=Array)
+        self.undo_manager.expand_scope(self._ycells)
 
     @property
     def version(self) -> str:

--- a/jupyter_ydoc/yunicode.py
+++ b/jupyter_ydoc/yunicode.py
@@ -31,7 +31,8 @@ class YUnicode(YBaseDoc):
         :type ydoc: :class:`pycrdt.Doc`, optional.
         """
         super().__init__(ydoc)
-        self._ydoc["source"] = self._ysource = Text()
+        self._ysource = self._ydoc.get("source", type=Text)
+        self.undo_manager.expand_scope(self._ysource)
 
     @property
     def version(self) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.7"
 keywords = ["jupyter", "ypy"]
 dependencies = [
     "importlib_metadata >=3.6; python_version<'3.10'",
-    "pycrdt >=0.8.1,<0.9.0",
+    "pycrdt >=0.9.0,<0.10.0",
 ]
 
 [[project.authors]]
@@ -31,7 +31,7 @@ test = [
     "pytest",
     "pytest-asyncio",
     "websockets >=10.0",
-    "pycrdt-websocket >=0.12.6,<0.13.0",
+    "pycrdt-websocket >=0.14.1,<0.15.0",
 ]
 docs = [
     "sphinx",

--- a/tests/test_ydocs.py
+++ b/tests/test_ydocs.py
@@ -1,27 +1,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from jupyter_ydoc import YBlob, YNotebook
-
-
-def test_yblob():
-    yblob = YBlob()
-    assert yblob.get() == b""
-    yblob.set(b"012")
-    assert yblob.get() == b"012"
-    changes = []
-
-    def callback(topic, event):
-        print(topic, event)
-        changes.append((topic, event))
-
-    yblob.observe(callback)
-    yblob.set(b"345")
-    assert len(changes) == 1
-    topic, event = changes[0]
-    assert topic == "source"
-    assert event.keys["bytes"]["oldValue"] == b"012"
-    assert event.keys["bytes"]["newValue"] == b"345"
+from jupyter_ydoc import YNotebook
 
 
 def test_ynotebook_undo_manager():

--- a/tests/test_ydocs.py
+++ b/tests/test_ydocs.py
@@ -1,0 +1,55 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from jupyter_ydoc import YBlob, YNotebook
+
+
+def test_yblob():
+    yblob = YBlob()
+    assert yblob.get() == b""
+    yblob.set(b"012")
+    assert yblob.get() == b"012"
+    changes = []
+
+    def callback(topic, event):
+        print(topic, event)
+        changes.append((topic, event))
+
+    yblob.observe(callback)
+    yblob.set(b"345")
+    assert len(changes) == 1
+    topic, event = changes[0]
+    assert topic == "source"
+    assert event.keys["bytes"]["oldValue"] == b"012"
+    assert event.keys["bytes"]["newValue"] == b"345"
+
+
+def test_ynotebook_undo_manager():
+    ynotebook = YNotebook()
+    cell0 = {
+        "cell_type": "code",
+        "source": "Hello",
+    }
+    ynotebook.append_cell(cell0)
+    source = ynotebook.ycells[0]["source"]
+    source += ", World!\n"
+    cell1 = {
+        "cell_type": "code",
+        "source": "print(1 + 1)\n",
+    }
+    ynotebook.append_cell(cell1)
+    assert len(ynotebook.ycells) == 2
+    assert str(ynotebook.ycells[0]["source"]) == "Hello, World!\n"
+    assert str(ynotebook.ycells[1]["source"]) == "print(1 + 1)\n"
+    assert ynotebook.undo_manager.can_undo()
+    ynotebook.undo_manager.undo()
+    assert len(ynotebook.ycells) == 1
+    assert str(ynotebook.ycells[0]["source"]) == "Hello, World!\n"
+    assert ynotebook.undo_manager.can_undo()
+    ynotebook.undo_manager.undo()
+    assert len(ynotebook.ycells) == 1
+    assert str(ynotebook.ycells[0]["source"]) == "Hello"
+    assert ynotebook.undo_manager.can_undo()
+    ynotebook.undo_manager.undo()
+    assert len(ynotebook.ycells) == 0
+    assert not ynotebook.undo_manager.can_undo()


### PR DESCRIPTION
This is a cherry-pick of https://github.com/jupyter-server/jupyter_ydoc/commit/8e3f25bdcfb8ed36cd740dd958d5d04580cd54ef to backport it to `jupyter-ydoc` v2:
- https://github.com/jupyter-server/jupyter_ydoc/pull/248