### PR TITLE
Fix attachments change attribute assignment

### DIFF
--- a/javascript/src/ycell.ts
+++ b/javascript/src/ycell.ts
@@ -958,7 +958,7 @@ class YAttachmentCell
 
     if (modelEvent && modelEvent.keysChanged.has('attachments')) {
       const change = modelEvent.changes.keys.get('attachments');
-      changes.executionCountChange = {
+      changes.attachmentsChange = {
         oldValue: change!.oldValue,
         newValue: this.ymodel.get('attachments')
       };


### PR DESCRIPTION
It looks like a copy-paste error meant that changes to attachments might have been not correctly noticed on the frontend.