### PR TITLE
Revert #266

### DIFF
--- a/jupyter_ydoc/ynotebook.py
+++ b/jupyter_ydoc/ynotebook.py
@@ -225,7 +225,17 @@ class YNotebook(YBaseDoc):
         nb_without_cells = {key: value[key] for key in value.keys() if key != "cells"}
         nb = copy.deepcopy(nb_without_cells)
         cast_all(nb, int, float)  # Yjs expects numbers to be floating numbers
-        cells = value["cells"]
+        cells = value["cells"] or [
+            {
+                "cell_type": "code",
+                "execution_count": None,
+                # auto-created empty code cell without outputs ought be trusted
+                "metadata": {"trusted": True},
+                "outputs": [],
+                "source": "",
+                "id": str(uuid4()),
+            }
+        ]
 
         with self._ydoc.transaction():
             # clear document


### PR DESCRIPTION
- #266 makes the creation of a new notebook in RTC with no cell, which we don't want by default.
- https://github.com/jupyterlab/jupyterlab/pull/16732 allows to configure this behavior.