### PR TITLE
Fix stream output

### DIFF
--- a/jupyter_ydoc/ynotebook.py
+++ b/jupyter_ydoc/ynotebook.py
@@ -166,7 +166,12 @@ class YNotebook(YBaseDoc):
             outputs = cell.get("outputs", [])
             for idx, output in enumerate(outputs):
                 if output.get("output_type") == "stream":
-                    output["text"] = Array(output.get("text", []))
+                    text = output.get("text", "")
+                    if isinstance(text, str):
+                        ytext = Text(text)
+                    else:
+                        ytext = Text("".join(text))
+                    output["text"] = ytext
                 outputs[idx] = Map(output)
             cell["outputs"] = Array(outputs)
             cell["execution_state"] = "idle"

--- a/tests/test_pycrdt_yjs.py
+++ b/tests/test_pycrdt_yjs.py
@@ -90,7 +90,7 @@ async def test_ypy_yjs_1(yws_server, yjs_client):
         ydoc, Websocket(websocket, room_name)
     ):
         output_text = ynotebook.ycells[0]["outputs"][0]["text"]
-        assert output_text.to_py() == ["Hello,"]
+        assert output_text.to_py() == "Hello,"
         event = Event()
 
         def callback(_event):
@@ -101,7 +101,7 @@ async def test_ypy_yjs_1(yws_server, yjs_client):
         with move_on_after(10):
             await event.wait()
 
-        assert output_text.to_py() == ["Hello,", " World!"]
+        assert output_text.to_py() == "Hello,", " World!"
 
 
 def test_plotly_renderer():


### PR DESCRIPTION
Fixes #293.

Currently, the frontend expects a stream output "text" field to be a YText:
https://github.com/jupyter-server/jupyter_ydoc/blob/b20878676d4564641ac142804eaf27331ddb342c/javascript/src/ycell.ts#L791-L799
But the backend expects it to be a YArray:
https://github.com/jupyter-server/jupyter_ydoc/blob/b20878676d4564641ac142804eaf27331ddb342c/jupyter_ydoc/ynotebook.py#L165-L166

Creating a notebook with:
```py
text = "*" * 10_000

nb = """
{
 "cells": [
  {
   "cell_type": "code",
   "execution_count": 1,
   "id": "fa183e4b-bdfc-4789-a2ff-6ff197e31f3c",
   "metadata": {},
   "outputs": [
    {
     "name": "stdout",
     "output_type": "stream",
     "text": [
      "TEXT"
     ]
    }
   ],
   "source": [
   ]
  }
 ],
 "metadata": {
  "kernelspec": {
   "display_name": "Python 3 (ipykernel)",
   "language": "python",
   "name": "python3"
  },
  "language_info": {
   "codemirror_mode": {
    "name": "ipython",
    "version": 3
   },
   "file_extension": ".py",
   "mimetype": "text/x-python",
   "name": "python",
   "nbconvert_exporter": "python",
   "pygments_lexer": "ipython3",
   "version": "3.13.0"
  }
 },
 "nbformat": 4,
 "nbformat_minor": 5
}
""".replace("TEXT", text)

with open("Untitled.ipynb", "w") as f:
    f.write(nb)
```
And opening it in JupyterLab takes a few seconds and shows the following output:
```
*
*
*
...
```
Which is wrong because it should be one single line.
With this PR, the notebook opens instantly, showing a single line:
```
***...
```
@trungleduc I remember you updated the snapshots somewhere because you saw a mismatch like that. Was it in jupyter-collaboration?