### PR TITLE
Fix missing nbformat version

### DIFF
--- a/jupyter_ydoc/ynotebook.py
+++ b/jupyter_ydoc/ynotebook.py
@@ -202,7 +202,11 @@ class YNotebook(YBaseDoc):
         cells = []
         for i in range(len(self._ycells)):
             cell = self.get_cell(i)
-            if "id" in cell and meta.get("nbformat", 0) == 4 and meta.get("nbformat_minor", 0) <= 4:
+            if (
+                "id" in cell
+                and int(meta.get("nbformat", 0)) == 4
+                and int(meta.get("nbformat_minor", 0)) <= 4
+            ):
                 # strip cell IDs if we have notebook format 4.0-4.4
                 del cell["id"]
             if (

--- a/jupyter_ydoc/ynotebook.py
+++ b/jupyter_ydoc/ynotebook.py
@@ -202,7 +202,7 @@ class YNotebook(YBaseDoc):
         cells = []
         for i in range(len(self._ycells)):
             cell = self.get_cell(i)
-            if "id" in cell and meta["nbformat"] == 4 and meta["nbformat_minor"] <= 4:
+            if "id" in cell and meta.get("nbformat", 0) == 4 and meta.get("nbformat_minor", 0) <= 4:
                 # strip cell IDs if we have notebook format 4.0-4.4
                 del cell["id"]
             if (


### PR DESCRIPTION
Fix an inconsistency to allow missing format information at

https://github.com/jupyter-server/jupyter_ydoc/blob/2b8e788695905299ff956121345859e07fa903aa/jupyter_ydoc/ynotebook.py#L205

This is to aligned with the tolerance implemented a bit later:

https://github.com/jupyter-server/jupyter_ydoc/blob/2b8e788695905299ff956121345859e07fa903aa/jupyter_ydoc/ynotebook.py#L216-L221