### PR TITLE
Increase pycrdt compatible version range

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.7"
 keywords = ["jupyter", "ypy"]
 dependencies = [
     "importlib_metadata >=3.6; python_version<'3.10'",
-    "pycrdt >=0.10.1,<0.11.0",
+    "pycrdt >=0.10.1,<0.13.0",
 ]
 
 [[project.authors]]


### PR DESCRIPTION
Same as #307 but for the `2.x` branch.