### PR TITLE
Fix including Typescript source in package

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -20,7 +20,7 @@
     },
     "files": [
         "lib/**/*.{d.ts,js,js.map,json}",
-        "src/**/*.{ts}"
+        "src/**/*.ts"
     ],
     "scripts": {
         "build": "tsc -b",


### PR DESCRIPTION
The current files selector is not correct and the typescript files are not included in the package making debug harder.