### PR TITLE
Set `undoManager` in constructor for cells in notebook

### DIFF
--- a/javascript/src/ynotebook.ts
+++ b/javascript/src/ynotebook.ts
@@ -227,10 +227,6 @@ export class YNotebook
       );
     });
 
-    yCells.forEach(c => {
-      c.setUndoManager();
-    });
-
     return yCells;
   }
 
@@ -592,7 +588,6 @@ export class YNotebook
       const type = (item.content as Y.ContentType).type as Y.Map<any>;
       if (!this._ycellMapping.has(type)) {
         const c = createCellModelFromSharedType(type, { notebook: this });
-        c!.setUndoManager();
         this._ycellMapping.set(type, c);
       }
     });


### PR DESCRIPTION
A fix for https://github.com/jupyterlab/jupyterlab/issues/17247.

Previously an assumption was made that the undo manager can be only instantiated after the cell's `ymodel` gets inserted into the notebook (more precisely, after it gets added to the `_ycells` array). This is because doing so before that resulted in an error being raised due to `cell.ymodel.doc` being `null` (as the docs is set on `ymodel` only when it gets inserted into an `YArrray` with a document).

However, the `doc` set during insertion is just the notebook's `doc` and we can access it earlier in the cell's constructor under `this._notebook.ydoc`; further, the `Y.UndoManager` has a way to pass a doc explicitly if one cannot rely on extraction from `ymodel` (which is exactly the case we face).

That assumption dates back to https://github.com/jupyterlab/jupyterlab/pull/13168 (around the same time as the `doc` parameter was added to yjs in https://github.com/yjs/yjs/commit/6fa8778fc76aa1ec928e6e04e4485eb75062a42e).