### PR TITLE
Bump `ip` from 2.0.0 to 2.0.1

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2803,9 +2803,9 @@ __metadata:
   linkType: hard
 
 "ip@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "ip@npm:2.0.0"
-  checksum: cfcfac6b873b701996d71ec82a7dd27ba92450afdb421e356f44044ed688df04567344c36cbacea7d01b1c39a4c732dc012570ebe9bebfb06f27314bca625349
+  version: 2.0.1
+  resolution: "ip@npm:2.0.1"
+  checksum: d765c9fd212b8a99023a4cde6a558a054c298d640fec1020567494d257afd78ca77e37126b1a3ef0e053646ced79a816bf50621d38d5e768cdde0431fa3b0d35
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`ip@2.0.0` (an NPM dependency) is impacted by `CVE-2023-42282`: https://github.com/advisories/GHSA-78xj-cgh5-2h22

This CVE is patched in `ip@2.0.1`. This PR bumps `ip` from `2.0.0` to `2.0.1`.