### PR TITLE
Add `clearOutputs()` method to `ISharedCodeCell`

### DIFF
--- a/javascript/src/api.ts
+++ b/javascript/src/api.ts
@@ -575,7 +575,7 @@ export interface ISharedCodeCell
   /**
    * Clear all outputs from the cell.
    */
-  clearOutputs(): void;
+  clearOutputs(origin: any): void;
 
   /**
    * Serialize the model to JSON.

--- a/javascript/src/api.ts
+++ b/javascript/src/api.ts
@@ -573,6 +573,11 @@ export interface ISharedCodeCell
   ): void;
 
   /**
+   * Clear all outputs from the cell.
+   */
+  clearOutputs(): void;
+
+  /**
    * Serialize the model to JSON.
    */
   toJSON(): nbformat.IBaseCell;

--- a/javascript/src/ycell.ts
+++ b/javascript/src/ycell.ts
@@ -868,6 +868,19 @@ export class YCodeCell
   }
 
   /**
+   * Clear all outputs from the cell.
+   */
+  clearOutputs(origin: any = null): void {
+    this.transact(
+      () => {
+        this._youtputs.delete(0, this._youtputs.length);
+      },
+      false,
+      origin
+    );
+  }
+
+  /**
    * Serialize the model to JSON.
    */
   toJSON(): nbformat.ICodeCell {

--- a/javascript/test/ycell.spec.ts
+++ b/javascript/test/ycell.spec.ts
@@ -333,3 +333,22 @@ describe('@jupyter/ydoc', () => {
     });
   });
 });
+
+test('should clear outputs from a code cell', () => {
+  const codeCell = YCodeCell.create();
+  const outputs = [
+    {
+      data: {
+        'text/plain': ['Hello, world!']
+      },
+      metadata: {},
+      output_type: 'execute_result'
+    }
+  ];
+
+  codeCell.setOutputs(outputs);
+  expect(codeCell.getOutputs()).toEqual(outputs);
+
+  codeCell.clearOutputs();
+  expect(codeCell.getOutputs()).toEqual([]);
+});


### PR DESCRIPTION
## References https://github.com/jupyterlab/jupyterlab/issues/17632

### Description
This PR introduces a `clearOutputs()` method to the `ISharedCodeCell` interface and its implementation in `YCodeCell`. This method provides a clean and direct way to remove all outputs from a code cell in the shared model.

This change is motivated by a bug in JupyterLab where uncoalesced stream outputs can persist in the cell output area. The root cause is that the frontend coalesces outputs, but the shared model retains multiple entries, making it tricky to clear all outputs using `updateOutputs()` when their lengths differ.