### PR TITLE
Preserve document_id state when setting notebook source

### DIFF
--- a/jupyter_ydoc/ynotebook.py
+++ b/jupyter_ydoc/ynotebook.py
@@ -250,7 +250,7 @@ class YNotebook(YBaseDoc):
             # clear document
             self._ymeta.clear()
             self._ycells.clear()
-            for key in [k for k in self._ystate.keys() if k not in ("dirty", "path")]:
+            for key in [k for k in self._ystate.keys() if k not in ("dirty", "path", "document_id")]:
                 del self._ystate[key]
 
             # initialize document


### PR DESCRIPTION
Preserve the `document_id` state that's used by Jupyter collaboration UI for server side execution mode.

Currently in jupyter-collaboration, if an out of band change happens (eg. user edits the file in non-RTC mode), the server will attempt to revert the document in memory to the source [here](https://github.com/jupyterlab/jupyter-collaboration/blob/499f8ff5df0dce6edaac7f79854292557fd12705/projects/jupyter-server-ydoc/jupyter_server_ydoc/rooms.py#L226), which is also the case in [Jupyverse](https://github.com/jupyter-server/jupyverse/blob/ac0e5a30999cee783b584e033a28093a25ad1630/plugins/yjs/fps_yjs/routes.py#L349).

It deletes `document_id` in ystate and propagates it in an update to clients, to which they won't be able to execute cells anymore if server side execution mode is enabled, since they won't be able to provide a `document_id` in the HTTP execution request body. They will have to refresh their tab and sync again, as `document_id` is actually [set on sync](https://github.com/jupyterlab/jupyter-collaboration/blob/499f8ff5df0dce6edaac7f79854292557fd12705/packages/docprovider/src/yprovider.ts#L168).