### PR TITLE
Add `remove_duplicate_cells()` public method to YNotebook

### DIFF
--- a/jupyter_ydoc/ynotebook.py
+++ b/jupyter_ydoc/ynotebook.py
@@ -1,6 +1,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import asyncio
 import copy
 import logging
 import warnings
@@ -483,7 +484,17 @@ class YNotebook(YBaseDoc):
         self.unobserve()
         self._subscriptions[self._ystate] = self._ystate.observe(partial(callback, "state"))
         self._subscriptions[self._ymeta] = self._ymeta.observe_deep(partial(callback, "meta"))
-        self._subscriptions[self._ycells] = self._ycells.observe_deep(partial(callback, "cells"))
+
+        def _on_cells_change(event: Any) -> None:
+            callback("cells", event)
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                self.remove_duplicate_cells()
+                return
+            loop.call_soon(self.remove_duplicate_cells)
+
+        self._subscriptions[self._ycells] = self._ycells.observe_deep(_on_cells_change)
 
     def _update_cell(self, old_cell: dict, new_cell: dict, old_ycell: Map) -> bool:
         if old_cell == new_cell:

--- a/jupyter_ydoc/ynotebook.py
+++ b/jupyter_ydoc/ynotebook.py
@@ -2,6 +2,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 import copy
+import logging
 import warnings
 from collections.abc import Callable, Iterator
 from functools import partial
@@ -14,6 +15,7 @@ from pycrdt import Array, Awareness, Doc, Map, Text
 from .utils import cast_all
 from .ybasedoc import YBaseDoc
 
+logger = logging.getLogger(__name__)
 # The default major version of the notebook format.
 NBFORMAT_MAJOR_VERSION = 4
 # The default minor version of the notebook format.
@@ -436,6 +438,40 @@ class YNotebook(YBaseDoc):
         """
         for val in self._set(value):
             await lowlevel.checkpoint()
+
+    def remove_duplicate_cells(self) -> int:
+        """
+        Removes cells with duplicate IDs, keeping the first occurrence.
+
+        This method allows callers (e.g. collaboration rooms) to trigger
+        deduplication without needing to know about cell internals.
+
+        :return: The number of duplicate cells removed.
+        :rtype: int
+        """
+        if len(self._ycells) == 0:
+            return 0
+
+        seen: set[str] = set()
+        to_delete: list[int] = []
+        for i, ycell in enumerate(self._ycells):
+            cell_id = ycell.get("id")
+            if cell_id is None:
+                continue
+            if cell_id in seen:
+                to_delete.append(i)
+            else:
+                seen.add(cell_id)
+
+        if not to_delete:
+            return 0
+
+        logger.warning("Removing %d duplicate cell(s)", len(to_delete))
+        with self._ydoc.transaction():
+            for i in reversed(to_delete):
+                del self._ycells[i]
+
+        return len(to_delete)
 
     def observe(self, callback: Callable[[str, Any], None]) -> None:
         """

--- a/tests/test_ynotebook.py
+++ b/tests/test_ynotebook.py
@@ -551,3 +551,34 @@ async def test_remove_duplicate_cells_no_duplicates():
     removed = nb.remove_duplicate_cells()
     assert removed == 0
     assert nb.cell_number == 2
+
+
+async def test_observe_triggers_dedup_on_cells_change():
+    """observe() auto-deduplicates when cells change."""
+    nb = YNotebook()
+    nb.set(
+        {
+            "cells": [
+                make_code_cell("print(1)", id="cell-A"),
+                make_code_cell("print(2)", id="cell-B"),
+            ]
+        }
+    )
+
+    changes = []
+    nb.observe(lambda target, event: changes.append(target))
+
+    # Insert a duplicate of the first cell
+    with nb.ydoc.transaction():
+        dup = Map({"id": "cell-A", "cell_type": "code", "source": "duplicate"})
+        nb.ycells.append(dup)
+
+    # The observer fires synchronously; dedup is scheduled via call_soon.
+    # Give the event loop a tick so the scheduled dedup runs.
+    await lowlevel.checkpoint()
+
+    assert nb.cell_number == 2
+    ids = [nb.ycells[i].get("id") for i in range(nb.cell_number)]
+    assert ids == ["cell-A", "cell-B"]
+    # The observer should have fired for both the insert and the dedup removal
+    assert "cells" in changes

--- a/tests/test_ynotebook.py
+++ b/tests/test_ynotebook.py
@@ -506,3 +506,48 @@ async def test_async_notebook():
     # check that the max blocking time is at least 20 times
     # smaller than if we did a blocking get:
     assert max_blocking_time < get_time / 20
+
+
+async def test_remove_duplicate_cells():
+    """remove_duplicate_cells removes duplicates and returns count."""
+    nb = YNotebook()
+    nb.set(
+        {
+            "cells": [
+                make_code_cell("print(1)", id="cell-A"),
+                make_code_cell("print(2)", id="cell-B"),
+            ]
+        }
+    )
+    assert nb.cell_number == 2
+
+    # Insert a duplicate of the first cell
+    with nb.ydoc.transaction():
+        dup = Map({"id": "cell-A", "cell_type": "code", "source": "duplicate"})
+        nb.ycells.append(dup)
+
+    assert nb.cell_number == 3
+
+    removed = nb.remove_duplicate_cells()
+
+    assert removed == 1
+    assert nb.cell_number == 2
+    ids = [nb.ycells[i].get("id") for i in range(nb.cell_number)]
+    assert ids == ["cell-A", "cell-B"]
+
+
+async def test_remove_duplicate_cells_no_duplicates():
+    """No-op when there are no duplicate cells."""
+    nb = YNotebook()
+    nb.set(
+        {
+            "cells": [
+                make_code_cell("print(1)", id="cell-A"),
+                make_code_cell("print(2)", id="cell-B"),
+            ]
+        }
+    )
+    assert nb.cell_number == 2
+    removed = nb.remove_duplicate_cells()
+    assert removed == 0
+    assert nb.cell_number == 2


### PR DESCRIPTION
## Summary

- Adds a public `remove_duplicate_cells()` method to `YNotebook` that scans for cells with duplicate IDs, keeps the first occurrence, and removes later duplicates within a single Y transaction
- Returns the count of removed duplicates and logs a warning when duplicates are found
- `YNotebook.observe()` now automatically triggers dedup when cells change via `call_soon`, so callers like `jupyter-server-ydoc` get dedup for free without any code changes

## Motivation

When multiple clients sync notebook content concurrently via the Y CRDT protocol, duplicate cells (cells sharing the same ID) can accumulate in the shared document. Without a public API on the document model, callers that want to clean up duplicates need to access `YNotebook` internals (`_ycells`, `_ydoc`) and understand cell structure — violating the separation of concerns between the document model and the server layer.

Since `jupyter-server-ydoc` already calls `observe()`, the auto-dedup kicks in with no changes needed on the collaboration side.

The existing deduplication in `_get()` (which handles duplicates at read time) is preserved as defense-in-depth.

## Test plan

- [x] `test_remove_duplicate_cells` — verifies duplicates are removed and return count is correct
- [x] `test_remove_duplicate_cells_no_duplicates` — verifies no-op when no duplicates exist
- [x] `test_observe_triggers_dedup_on_cells_change` — verifies the observer-driven dedup path end-to-end
- [x] All existing tests pass (38/38)

## Related

- https://github.com/jupyterlab/jupyter-collaboration/issues/545
- https://github.com/jupyter-server/jupyter_ydoc/issues/385