### PR TITLE
Add a fast path for intial set when opening large textual file

### DIFF
--- a/jupyter_ydoc/yunicode.py
+++ b/jupyter_ydoc/yunicode.py
@@ -74,6 +74,14 @@ class YUnicode(YBaseDoc):
             # to avoid side-effects such as cursor jumping to the top
             return
 
+        # Fast path for first load: avoid expensive byte diffing when the
+        # document has no content yet (e.g. opening very large text files).
+        if not old_value:
+            with self._ydoc.transaction():
+                if value:
+                    self._ysource += value
+            return
+
         before_bytes = old_value.encode("utf-8")
         after_bytes = value.encode("utf-8")
 

--- a/jupyter_ydoc/yunicode.py
+++ b/jupyter_ydoc/yunicode.py
@@ -76,10 +76,8 @@ class YUnicode(YBaseDoc):
 
         # Fast path for first load: avoid expensive byte diffing when the
         # document has no content yet (e.g. opening very large text files).
-        if not old_value:
-            with self._ydoc.transaction():
-                if value:
-                    self._ysource += value
+        if not old_value and value:
+            self._ysource += value
             return
 
         before_bytes = old_value.encode("utf-8")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dev = [
 test = [
     "pre-commit",
     "pytest",
+    "pytest-timeout",
     "httpx-ws >=0.5.2",
     "hypercorn >=0.16.0",
     "pycrdt-websocket >=0.16.0,<0.17.0",

--- a/tests/test_yunicode.py
+++ b/tests/test_yunicode.py
@@ -191,6 +191,17 @@ def test_set_hard_reload_if_very_different():
     ]
 
 
+@pytest.mark.timeout(15)
+def test_set_fast_path_for_large_initial_content():
+    text = YUnicode()
+
+    # Simulate opening a large (1GB) text file from an empty document.
+    large_content = "a" * (1024 * 1024 * 1024)
+    text.set(large_content)
+
+    assert text.get() == large_content
+
+
 @pytest.mark.parametrize(
     "initial, updated, granular",
     [


### PR DESCRIPTION
Handles the simple case of empty file for #401 