### PR TITLE
Set dirty state on document change

### DIFF
--- a/javascript/src/api.ts
+++ b/javascript/src/api.ts
@@ -326,7 +326,11 @@ export interface ISharedNotebook extends ISharedDocument {
    *
    * @returns The inserted cells.
    */
-  insertCells(index: number, cells: Array<SharedCell.Cell>, setDirty: boolean): ISharedCell[];
+  insertCells(
+    index: number,
+    cells: Array<SharedCell.Cell>,
+    setDirty: boolean
+  ): ISharedCell[];
 
   /**
    * Move a cell.

--- a/javascript/src/api.ts
+++ b/javascript/src/api.ts
@@ -122,6 +122,16 @@ interface ISharedDocumentNoSource extends ISharedBase {
   setState(key: string, value: JSONValue): void;
 
   /**
+   * Set the dirty state
+   */
+  setDirty(): void;
+
+  /**
+   * Clear the dirty state
+   */
+  clearDirty(): void;
+
+  /**
    * The changed signal.
    */
   readonly changed: ISignal<this, DocumentChange>;
@@ -312,10 +322,11 @@ export interface ISharedNotebook extends ISharedDocument {
    *
    * @param index Position to insert the cells.
    * @param cells Array of shared cells to insert.
+   * @param setDirty Whether to set the dirty state.
    *
    * @returns The inserted cells.
    */
-  insertCells(index: number, cells: Array<SharedCell.Cell>): ISharedCell[];
+  insertCells(index: number, cells: Array<SharedCell.Cell>, setDirty: boolean): ISharedCell[];
 
   /**
    * Move a cell.
@@ -347,8 +358,10 @@ export interface ISharedNotebook extends ISharedDocument {
    * @param from: The start index of the range to remove (inclusive).
    *
    * @param to: The end index of the range to remove (exclusive).
+   *
+   * @param setDirty: Whether to set the dirty state.
    */
-  deleteCellRange(from: number, to: number): void;
+  deleteCellRange(from: number, to: number, setDirty: boolean): void;
 
   /**
    * Override the notebook with a JSON-serialized document.
@@ -522,6 +535,16 @@ export interface ISharedBaseCell<
    * Serialize the model to JSON.
    */
   toJSON(): nbformat.IBaseCell;
+
+  /**
+   * Set the dirty state of the notebook
+   */
+  setDirty(): void;
+
+  /**
+   * Clear the dirty state of the notebook
+   */
+  clearDirty(): void;
 }
 
 export type IExecutionState = 'running' | 'idle';

--- a/javascript/src/api.ts
+++ b/javascript/src/api.ts
@@ -324,7 +324,7 @@ export interface ISharedNotebook extends ISharedDocument {
   insertCells(
     index: number,
     cells: Array<SharedCell.Cell>,
-    dirty: boolean
+    dirty?: boolean
   ): ISharedCell[];
 
   /**
@@ -360,7 +360,7 @@ export interface ISharedNotebook extends ISharedDocument {
    *
    * @param dirty: The dirty state to set.
    */
-  deleteCellRange(from: number, to: number, dirty: boolean): void;
+  deleteCellRange(from: number, to: number, dirty?: boolean): void;
 
   /**
    * Override the notebook with a JSON-serialized document.

--- a/javascript/src/api.ts
+++ b/javascript/src/api.ts
@@ -102,6 +102,11 @@ interface ISharedDocumentNoSource extends ISharedBase {
   readonly state: JSONObject;
 
   /**
+   * Document dirty state
+   */
+  dirty: boolean;
+
+  /**
    * Document awareness
    */
   readonly awareness: IAwareness;
@@ -123,13 +128,10 @@ interface ISharedDocumentNoSource extends ISharedBase {
 
   /**
    * Set the dirty state
+   *
+   * @param value New dirty state value
    */
-  setDirty(): void;
-
-  /**
-   * Clear the dirty state
-   */
-  clearDirty(): void;
+  setDirty(value: boolean): void;
 
   /**
    * The changed signal.
@@ -322,14 +324,14 @@ export interface ISharedNotebook extends ISharedDocument {
    *
    * @param index Position to insert the cells.
    * @param cells Array of shared cells to insert.
-   * @param setDirty Whether to set the dirty state.
+   * @param dirty The dirty state to set.
    *
    * @returns The inserted cells.
    */
   insertCells(
     index: number,
     cells: Array<SharedCell.Cell>,
-    setDirty: boolean
+    dirty: boolean
   ): ISharedCell[];
 
   /**
@@ -363,9 +365,9 @@ export interface ISharedNotebook extends ISharedDocument {
    *
    * @param to: The end index of the range to remove (exclusive).
    *
-   * @param setDirty: Whether to set the dirty state.
+   * @param dirty: The dirty state to set.
    */
-  deleteCellRange(from: number, to: number, setDirty: boolean): void;
+  deleteCellRange(from: number, to: number, dirty: boolean): void;
 
   /**
    * Override the notebook with a JSON-serialized document.
@@ -541,14 +543,11 @@ export interface ISharedBaseCell<
   toJSON(): nbformat.IBaseCell;
 
   /**
-   * Set the dirty state of the notebook
+   * Set the dirty state of the notebook the cell belongs to, if any.
+   *
+   * @param value New dirty state value
    */
-  setDirty(): void;
-
-  /**
-   * Clear the dirty state of the notebook
-   */
-  clearDirty(): void;
+  setDirty(value: boolean): void;
 }
 
 export type IExecutionState = 'running' | 'idle';

--- a/javascript/src/api.ts
+++ b/javascript/src/api.ts
@@ -127,13 +127,6 @@ interface ISharedDocumentNoSource extends ISharedBase {
   setState(key: string, value: JSONValue): void;
 
   /**
-   * Set the dirty state
-   *
-   * @param value New dirty state value
-   */
-  setDirty(value: boolean): void;
-
-  /**
    * The changed signal.
    */
   readonly changed: ISignal<this, DocumentChange>;
@@ -494,6 +487,11 @@ export interface ISharedBaseCell<
   readonly notebook: ISharedNotebook | null;
 
   /**
+   * The dirty state of the notebook that the cell belongs to, if any.
+   */
+  dirty: boolean;
+
+  /**
    * Get Cell id.
    *
    * @returns Cell id.
@@ -541,13 +539,6 @@ export interface ISharedBaseCell<
    * Serialize the model to JSON.
    */
   toJSON(): nbformat.IBaseCell;
-
-  /**
-   * Set the dirty state of the notebook the cell belongs to, if any.
-   *
-   * @param value New dirty state value
-   */
-  setDirty(value: boolean): void;
 }
 
 export type IExecutionState = 'running' | 'idle';

--- a/javascript/src/ycell.ts
+++ b/javascript/src/ycell.ts
@@ -61,7 +61,8 @@ export const createCellModelFromSharedType = (
  */
 export const createCell = (
   cell: SharedCell.Cell,
-  notebook?: YNotebook
+  notebook?: YNotebook,
+  dirty: boolean = true
 ): YCodeCell | YMarkdownCell | YRawCell => {
   const ymodel = new Y.Map();
   const ysource = new Y.Text();
@@ -76,7 +77,7 @@ export const createCell = (
     case 'markdown': {
       ycell = new YMarkdownCell(ymodel, ysource, { notebook }, ymetadata);
       if (cell.attachments != null) {
-        ycell.setAttachments(cell.attachments as nbformat.IAttachments);
+        ycell.setAttachments(cell.attachments as nbformat.IAttachments, dirty);
       }
       break;
     }
@@ -93,9 +94,9 @@ export const createCell = (
         ymetadata
       );
       const cCell = cell as Partial<nbformat.ICodeCell>;
-      ycell.execution_count = cCell.execution_count ?? null;
+      ycell.setExecutionCount(cCell.execution_count ?? null, dirty);
       if (cCell.outputs) {
-        ycell.setOutputs(cCell.outputs);
+        ycell.setOutputs(cCell.outputs, dirty);
       }
       break;
     }
@@ -103,18 +104,18 @@ export const createCell = (
       // raw
       ycell = new YRawCell(ymodel, ysource, { notebook }, ymetadata);
       if (cell.attachments) {
-        ycell.setAttachments(cell.attachments as nbformat.IAttachments);
+        ycell.setAttachments(cell.attachments as nbformat.IAttachments, dirty);
       }
       break;
     }
   }
 
   if (cell.metadata != null) {
-    ycell.setMetadata(cell.metadata);
+    ycell.setMetadata(cell.metadata, dirty);
   }
   if (cell.source != null) {
     ycell.setSource(
-      typeof cell.source === 'string' ? cell.source : cell.source.join('')
+      typeof cell.source === 'string' ? cell.source : cell.source.join(''), dirty
     );
   }
   return ycell;
@@ -271,24 +272,13 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
   }
 
   /**
-   * Set the dirty state of the notebook
+   * Set the dirty state of the notebook the cell belongs to, if any.
+   *
+   * @param value New dirty state value
    */
-  setDirty(): void {
+  setDirty(value: boolean): void {
     if (this.notebook !== null) {
-      this.notebook!.transact(() => {
-        this.notebook!.setState('dirty', true);
-      }, false);
-    }
-  }
-
-  /**
-   * Clear the dirty state of the notebook
-   */
-  clearDirty(): void {
-    if (this.notebook !== null) {
-      this.notebook!.transact(() => {
-        this.notebook!.setState('dirty', false);
-      }, false);
+      this.notebook!.setDirty(value);
     }
   }
 
@@ -403,12 +393,14 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
    * Sets cell's source.
    *
    * @param value: New source.
+   * @param dirty: The dirty state to set.
    */
-  setSource(value: string): void {
+  setSource(value: string, dirty: boolean = true): void {
     this.transact(() => {
       this.ysource.delete(0, this.ysource.length);
       this.ysource.insert(0, value);
     });
+    this.setDirty(dirty);
     // @todo Do we need proper replace semantic? This leads to issues in editor bindings because they don't switch source.
     // this.ymodel.set('source', new Y.Text(value));
   }
@@ -430,6 +422,7 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
       ysource.insert(start, value);
       ysource.delete(start + value.length, end - start);
     });
+    this.setDirty(true);
   }
 
   /**
@@ -459,6 +452,7 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
         this._ymetadata.delete('collapsed');
       }
     }, false);
+    this.setDirty(true);
   }
 
   /**
@@ -495,13 +489,18 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
    *
    * @param metadata Cell's metadata key or cell's metadata.
    * @param value Metadata value
+   * @param dirty The dirty state to set.
    */
   setMetadata(metadata: Partial<Metadata>): void;
+  setMetadata(metadata: Partial<Metadata>, dirty: boolean): void;
   setMetadata(metadata: string, value: PartialJSONValue): void;
+  setMetadata(metadata: string, value: PartialJSONValue, dirty: boolean): void;
   setMetadata(
     metadata: Partial<Metadata> | string,
-    value?: PartialJSONValue
+    value?: PartialJSONValue,
+    dirty?: boolean
   ): void {
+    const _dirty = (typeof dirty === 'undefined') ? true : dirty;
     if (typeof metadata === 'string') {
       if (typeof value === 'undefined') {
         throw new TypeError(
@@ -538,6 +537,7 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
           }
         }
       }, false);
+      this.setDirty(_dirty);
     } else {
       const clone = JSONExt.deepCopy(metadata) as any;
       if (clone.collapsed != null) {
@@ -552,6 +552,7 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
             this._ymetadata.set(key, value);
           }
         }, false);
+        this.setDirty(_dirty);
       }
     }
   }
@@ -749,6 +750,10 @@ export class YCodeCell
     return this.ymodel.get('execution_count') || null;
   }
   set execution_count(count: number | null) {
+    this.setExecutionCount(count);
+  }
+
+  setExecutionCount(count: number | null, dirty: boolean = true) {
     // Do not use `this.execution_count`. When initializing the
     // cell, we need to set execution_count to `null` if we compare
     // using `this.execution_count` it will return `null` and we will
@@ -757,6 +762,7 @@ export class YCodeCell
       this.transact(() => {
         this.ymodel.set('execution_count', count);
       }, false);
+      this.setDirty(dirty);
     }
   }
 
@@ -771,6 +777,7 @@ export class YCodeCell
       this.transact(() => {
         this.ymodel.set('execution_state', state);
       }, false);
+      this.setDirty(true);
     }
   }
 
@@ -822,12 +829,13 @@ export class YCodeCell
   /**
    * Replace all outputs.
    */
-  setOutputs(outputs: Array<nbformat.IOutput>): void {
+  setOutputs(outputs: Array<nbformat.IOutput>, dirty: boolean = true): void {
     this.transact(() => {
       this._youtputs.delete(0, this._youtputs.length);
       const newOutputs = this.createOutputs(outputs);
       this._youtputs.insert(0, newOutputs);
     }, false);
+    this.setDirty(dirty);
   }
 
   /**
@@ -844,6 +852,7 @@ export class YCodeCell
       false,
       origin
     );
+    this.setDirty(true);
   }
 
   /**
@@ -859,6 +868,7 @@ export class YCodeCell
       false,
       origin
     );
+    this.setDirty(true);
   }
 
   /**
@@ -887,6 +897,7 @@ export class YCodeCell
       false,
       origin
     );
+    this.setDirty(true);
   }
 
   /**
@@ -900,6 +911,7 @@ export class YCodeCell
       false,
       origin
     );
+    this.setDirty(true);
   }
 
   /**
@@ -995,8 +1007,9 @@ class YAttachmentCell
    * Sets the cell attachments
    *
    * @param attachments: The cell attachments.
+   * @param dirty: The dirty state to set.
    */
-  setAttachments(attachments: nbformat.IAttachments | undefined): void {
+  setAttachments(attachments: nbformat.IAttachments | undefined, dirty: boolean = true): void {
     this.transact(() => {
       if (attachments == null) {
         this.ymodel.delete('attachments');
@@ -1004,6 +1017,7 @@ class YAttachmentCell
         this.ymodel.set('attachments', attachments);
       }
     }, false);
+    this.setDirty(dirty);
   }
 
   /**

--- a/javascript/src/ycell.ts
+++ b/javascript/src/ycell.ts
@@ -499,7 +499,7 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
     value?: PartialJSONValue,
     dirty?: boolean
   ): void {
-    const _dirty = typeof dirty === 'undefined' ? true : dirty;
+    const _dirty = dirty ?? true;
     if (typeof metadata === 'string') {
       if (typeof value === 'undefined') {
         throw new TypeError(

--- a/javascript/src/ycell.ts
+++ b/javascript/src/ycell.ts
@@ -292,7 +292,6 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
     }
   }
 
-
   /**
    * Cell input content.
    */

--- a/javascript/src/ycell.ts
+++ b/javascript/src/ycell.ts
@@ -271,6 +271,29 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
   }
 
   /**
+   * Set the dirty state of the notebook
+   */
+  setDirty(): void {
+    if (this.notebook !== null) {
+      this.notebook!.transact(() => {
+        this.notebook!.setState('dirty', true);
+      }, false);
+    }
+  }
+
+  /**
+   * Clear the dirty state of the notebook
+   */
+  clearDirty(): void {
+    if (this.notebook !== null) {
+      this.notebook!.transact(() => {
+        this.notebook!.setState('dirty', false);
+      }, false);
+    }
+  }
+
+
+  /**
    * Cell input content.
    */
   get source(): string {

--- a/javascript/src/ycell.ts
+++ b/javascript/src/ycell.ts
@@ -273,12 +273,21 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
   }
 
   /**
+   * The dirty state of the notebook the cell belongs to, if any.
+   */
+  get dirty(): boolean {
+     return this.notebook?.dirty === true;
+  }
+
+  /**
    * Set the dirty state of the notebook the cell belongs to, if any.
    *
    * @param value New dirty state value
    */
-  setDirty(value: boolean): void {
-     this.notebook?.setDirty(value);
+  set dirty(value: boolean) {
+    if (this.notebook) {
+      this.notebook.dirty = value;
+    }
   }
 
   /**
@@ -399,7 +408,7 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
       this.ysource.delete(0, this.ysource.length);
       this.ysource.insert(0, value);
     });
-    this.setDirty(dirty);
+    this.dirty = dirty;
     // @todo Do we need proper replace semantic? This leads to issues in editor bindings because they don't switch source.
     // this.ymodel.set('source', new Y.Text(value));
   }
@@ -421,7 +430,7 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
       ysource.insert(start, value);
       ysource.delete(start + value.length, end - start);
     });
-    this.setDirty(true);
+    this.dirty = true;
   }
 
   /**
@@ -451,7 +460,7 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
         this._ymetadata.delete('collapsed');
       }
     }, false);
-    this.setDirty(true);
+    this.dirty = true;
   }
 
   /**
@@ -536,7 +545,7 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
           }
         }
       }, false);
-      this.setDirty(_dirty);
+      this.dirty = _dirty;
     } else {
       const clone = JSONExt.deepCopy(metadata) as any;
       if (clone.collapsed != null) {
@@ -551,7 +560,7 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
             this._ymetadata.set(key, value);
           }
         }, false);
-        this.setDirty(_dirty);
+        this.dirty = _dirty;
       }
     }
   }
@@ -761,7 +770,7 @@ export class YCodeCell
       this.transact(() => {
         this.ymodel.set('execution_count', count);
       }, false);
-      this.setDirty(dirty);
+      this.dirty = dirty;
     }
   }
 
@@ -776,7 +785,7 @@ export class YCodeCell
       this.transact(() => {
         this.ymodel.set('execution_state', state);
       }, false);
-      this.setDirty(true);
+      this.dirty = true;
     }
   }
 
@@ -834,7 +843,7 @@ export class YCodeCell
       const newOutputs = this.createOutputs(outputs);
       this._youtputs.insert(0, newOutputs);
     }, false);
-    this.setDirty(dirty);
+    this.dirty = dirty;
   }
 
   /**
@@ -851,7 +860,7 @@ export class YCodeCell
       false,
       origin
     );
-    this.setDirty(true);
+    this.dirty = true;
   }
 
   /**
@@ -867,7 +876,7 @@ export class YCodeCell
       false,
       origin
     );
-    this.setDirty(true);
+    this.dirty = true;
   }
 
   /**
@@ -896,7 +905,7 @@ export class YCodeCell
       false,
       origin
     );
-    this.setDirty(true);
+    this.dirty = true;
   }
 
   /**
@@ -910,7 +919,7 @@ export class YCodeCell
       false,
       origin
     );
-    this.setDirty(true);
+    this.dirty = true;
   }
 
   /**
@@ -1019,7 +1028,7 @@ class YAttachmentCell
         this.ymodel.set('attachments', attachments);
       }
     }, false);
-    this.setDirty(dirty);
+    this.dirty = dirty;
   }
 
   /**

--- a/javascript/src/ycell.ts
+++ b/javascript/src/ycell.ts
@@ -513,10 +513,9 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
   setMetadata(metadata: string, value: PartialJSONValue, dirty: boolean): void;
   setMetadata(
     metadata: Partial<Metadata> | string,
-    value?: PartialJSONValue,
+    value?: PartialJSONValue | boolean,
     dirty?: boolean
   ): void {
-    const _dirty = dirty ?? true;
     if (typeof metadata === 'string') {
       if (typeof value === 'undefined') {
         throw new TypeError(
@@ -553,7 +552,7 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
           }
         }
       }, false);
-      this.dirty = _dirty;
+      this.dirty = dirty ?? true;
     } else {
       const clone = JSONExt.deepCopy(metadata) as any;
       if (clone.collapsed != null) {
@@ -568,7 +567,7 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
             this._ymetadata.set(key, value);
           }
         }, false);
-        this.dirty = _dirty;
+        this.dirty = (value as boolean | undefined) ?? true;
       }
     }
   }

--- a/javascript/src/ycell.ts
+++ b/javascript/src/ycell.ts
@@ -276,7 +276,7 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
    * The dirty state of the notebook the cell belongs to, if any.
    */
   get dirty(): boolean {
-     return this.notebook?.dirty === true;
+    return this.notebook?.dirty === true;
   }
 
   /**

--- a/javascript/src/ycell.ts
+++ b/javascript/src/ycell.ts
@@ -793,7 +793,6 @@ export class YCodeCell
       this.transact(() => {
         this.ymodel.set('execution_state', state);
       }, false);
-      this.dirty = true;
     }
   }
 

--- a/javascript/src/ycell.ts
+++ b/javascript/src/ycell.ts
@@ -343,14 +343,22 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
    * Undo an operation.
    */
   undo(): boolean {
-    return !!this.undoManager?.undo();
+    const undone = !!this.undoManager?.undo();
+    if (undone) {
+      this.dirty = true;
+    }
+    return undone;
   }
 
   /**
    * Redo an operation.
    */
   redo(): boolean {
-    return !!this.undoManager?.redo();
+    const redone = !!this.undoManager?.redo();
+    if (redone) {
+      this.dirty = true;
+    }
+    return redone;
   }
 
   /**

--- a/javascript/src/ycell.ts
+++ b/javascript/src/ycell.ts
@@ -115,7 +115,8 @@ export const createCell = (
   }
   if (cell.source != null) {
     ycell.setSource(
-      typeof cell.source === 'string' ? cell.source : cell.source.join(''), dirty
+      typeof cell.source === 'string' ? cell.source : cell.source.join(''),
+      dirty
     );
   }
   return ycell;
@@ -500,7 +501,7 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
     value?: PartialJSONValue,
     dirty?: boolean
   ): void {
-    const _dirty = (typeof dirty === 'undefined') ? true : dirty;
+    const _dirty = typeof dirty === 'undefined' ? true : dirty;
     if (typeof metadata === 'string') {
       if (typeof value === 'undefined') {
         throw new TypeError(
@@ -1009,7 +1010,10 @@ class YAttachmentCell
    * @param attachments: The cell attachments.
    * @param dirty: The dirty state to set.
    */
-  setAttachments(attachments: nbformat.IAttachments | undefined, dirty: boolean = true): void {
+  setAttachments(
+    attachments: nbformat.IAttachments | undefined,
+    dirty: boolean = true
+  ): void {
     this.transact(() => {
       if (attachments == null) {
         this.ymodel.delete('attachments');

--- a/javascript/src/ycell.ts
+++ b/javascript/src/ycell.ts
@@ -278,9 +278,7 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
    * @param value New dirty state value
    */
   setDirty(value: boolean): void {
-    if (this.notebook !== null) {
-      this.notebook!.setDirty(value);
-    }
+     this.notebook?.setDirty(value);
   }
 
   /**

--- a/javascript/src/ydocument.ts
+++ b/javascript/src/ydocument.ts
@@ -146,6 +146,24 @@ export abstract class YDocument<T extends DocumentChange>
   }
 
   /**
+   * Set the dirty state
+   */
+  setDirty(): void {
+    this.transact(() => {
+      this.setState('dirty', true);
+    }, false);
+  }
+
+  /**
+   * Clear the dirty state
+   */
+  clearDirty(): void {
+    this.transact(() => {
+      this.setState('dirty', false);
+    }, false);
+  }
+
+  /**
    * Get the document source
    *
    * @returns The source
@@ -181,14 +199,22 @@ export abstract class YDocument<T extends DocumentChange>
    * Undo an operation.
    */
   undo(): boolean {
-    return !!this.undoManager.undo();
+    const undone = !!this.undoManager.undo();
+    if (undone) {
+      this.setDirty();
+    }
+    return undone;
   }
 
   /**
    * Redo an operation.
    */
   redo(): boolean {
-    return !!this.undoManager.redo();
+    const redone = !!this.undoManager.redo();
+    if (redone) {
+      this.setDirty();
+    }
+    return redone;
   }
 
   /**

--- a/javascript/src/ydocument.ts
+++ b/javascript/src/ydocument.ts
@@ -104,7 +104,9 @@ export abstract class YDocument<T extends DocumentChange>
    * @param value The dirty state to set
    */
   set dirty(value: boolean) {
-    this.setDirty(value);
+    this.transact(() => {
+      this.setState('dirty', value);
+    }, false); // This change is not be undoable.
   }
 
   /**
@@ -162,17 +164,6 @@ export abstract class YDocument<T extends DocumentChange>
   }
 
   /**
-   * Set the dirty state
-   *
-   * @param value New dirty state value
-   */
-  setDirty(value: boolean): void {
-    this.transact(() => {
-      this.setState('dirty', value);
-    }, false); // This change is not be undoable.
-  }
-
-  /**
    * Get the document source
    *
    * @returns The source
@@ -210,7 +201,7 @@ export abstract class YDocument<T extends DocumentChange>
   undo(): boolean {
     const undone = !!this.undoManager.undo();
     if (undone) {
-      this.setDirty(true);
+      this.dirty = true;
     }
     return undone;
   }
@@ -221,7 +212,7 @@ export abstract class YDocument<T extends DocumentChange>
   redo(): boolean {
     const redone = !!this.undoManager.redo();
     if (redone) {
-      this.setDirty(true);
+      this.dirty = true;
     }
     return redone;
   }

--- a/javascript/src/ydocument.ts
+++ b/javascript/src/ydocument.ts
@@ -92,6 +92,22 @@ export abstract class YDocument<T extends DocumentChange>
   }
 
   /**
+   * Document dirty state
+   */
+  get dirty(): boolean {
+    return this.ystate.get('dirty') === true;
+  }
+
+  /**
+   * Set the document dirty state
+   *
+   * @param value The dirty state to set
+   */
+  set dirty(value: boolean) {
+    this.setDirty(value);
+  }
+
+  /**
    * Whether the object can undo changes.
    */
   canUndo(): boolean {
@@ -147,20 +163,13 @@ export abstract class YDocument<T extends DocumentChange>
 
   /**
    * Set the dirty state
+   *
+   * @param value New dirty state value
    */
-  setDirty(): void {
+  setDirty(value: boolean): void {
     this.transact(() => {
-      this.setState('dirty', true);
-    }, false);
-  }
-
-  /**
-   * Clear the dirty state
-   */
-  clearDirty(): void {
-    this.transact(() => {
-      this.setState('dirty', false);
-    }, false);
+      this.setState('dirty', value);
+    }, false);  // This change is not be undoable.
   }
 
   /**
@@ -201,7 +210,7 @@ export abstract class YDocument<T extends DocumentChange>
   undo(): boolean {
     const undone = !!this.undoManager.undo();
     if (undone) {
-      this.setDirty();
+      this.setDirty(true);
     }
     return undone;
   }
@@ -212,7 +221,7 @@ export abstract class YDocument<T extends DocumentChange>
   redo(): boolean {
     const redone = !!this.undoManager.redo();
     if (redone) {
-      this.setDirty();
+      this.setDirty(true);
     }
     return redone;
   }

--- a/javascript/src/ydocument.ts
+++ b/javascript/src/ydocument.ts
@@ -169,7 +169,7 @@ export abstract class YDocument<T extends DocumentChange>
   setDirty(value: boolean): void {
     this.transact(() => {
       this.setState('dirty', value);
-    }, false);  // This change is not be undoable.
+    }, false); // This change is not be undoable.
   }
 
   /**

--- a/javascript/src/yfile.ts
+++ b/javascript/src/yfile.ts
@@ -102,7 +102,7 @@ export class YFile
       ysource.insert(start, value);
       ysource.delete(start + value.length, end - start);
     });
-    this.setDirty(true);
+    this.dirty = true;
   }
 
   /**

--- a/javascript/src/yfile.ts
+++ b/javascript/src/yfile.ts
@@ -102,7 +102,7 @@ export class YFile
       ysource.insert(start, value);
       ysource.delete(start + value.length, end - start);
     });
-    this.setDirty();
+    this.setDirty(true);
   }
 
   /**

--- a/javascript/src/yfile.ts
+++ b/javascript/src/yfile.ts
@@ -102,6 +102,7 @@ export class YFile
       ysource.insert(start, value);
       ysource.delete(start + value.length, end - start);
     });
+    this.setDirty();
   }
 
   /**

--- a/javascript/src/ynotebook.ts
+++ b/javascript/src/ynotebook.ts
@@ -212,7 +212,8 @@ export class YNotebook
    */
   insertCells(
     index: number,
-    cells: SharedCell.Cell[]
+    cells: SharedCell.Cell[],
+    setDirty: boolean = true
   ): YBaseCell<nbformat.IBaseCellMetadata>[] {
     const yCells = cells.map(c => {
       const cell = createCell(c, this);
@@ -226,6 +227,10 @@ export class YNotebook
         yCells.map(cell => cell.ymodel)
       );
     });
+
+    if (setDirty) {
+      this.setDirty();
+    }
 
     return yCells;
   }
@@ -259,6 +264,8 @@ export class YNotebook
         clones.map(clone => createCell(clone, this).ymodel)
       );
     });
+
+    this.setDirty();
   }
 
   /**
@@ -276,11 +283,15 @@ export class YNotebook
    * @param from: The start index of the range to remove (inclusive).
    * @param to: The end index of the range to remove (exclusive).
    */
-  deleteCellRange(from: number, to: number): void {
+  deleteCellRange(from: number, to: number, setDirty: boolean = true): void {
     // Cells will be removed from the mapping in the model event listener.
     this.transact(() => {
       this._ycells.delete(from, to - from);
     });
+
+    if (setDirty) {
+      this.setDirty();
+    }
   }
 
   /**
@@ -374,6 +385,8 @@ export class YNotebook
             ymetadata.set(key, value);
           }
         });
+
+        this.setDirty();
       }
     }
   }
@@ -398,6 +411,8 @@ export class YNotebook
         ymetadata.set(key, value);
       }
     });
+
+    this.setDirty();
   }
 
   /**
@@ -450,8 +465,8 @@ export class YNotebook
         }
         return cell;
       });
-      this.insertCells(this.cells.length, ycells);
-      this.deleteCellRange(0, this.cells.length);
+      this.insertCells(this.cells.length, ycells, false);
+      this.deleteCellRange(0, this.cells.length, false);
     });
   }
 

--- a/javascript/src/ynotebook.ts
+++ b/javascript/src/ynotebook.ts
@@ -229,7 +229,7 @@ export class YNotebook
       );
     });
 
-    this.setDirty(dirty);
+    this.dirty = dirty;
 
     return yCells;
   }
@@ -264,7 +264,7 @@ export class YNotebook
       );
     });
 
-    this.setDirty(true);
+    this.dirty = true;
   }
 
   /**
@@ -288,7 +288,7 @@ export class YNotebook
     this.transact(() => {
       this._ycells.delete(from, to - from);
     });
-    this.setDirty(dirty);
+    this.dirty = dirty;
   }
 
   /**
@@ -383,7 +383,7 @@ export class YNotebook
           }
         });
 
-        this.setDirty(true);
+        this.dirty = true;
       }
     }
   }
@@ -409,7 +409,7 @@ export class YNotebook
       }
     });
 
-    this.setDirty(true);
+    this.dirty = true;
   }
 
   /**

--- a/javascript/src/ynotebook.ts
+++ b/javascript/src/ynotebook.ts
@@ -89,7 +89,7 @@ export class YNotebook
       metadata: options.data?.metadata ?? {}
     };
 
-    ynotebook.fromJSON(data);
+    ynotebook.fromJSON(data, false);
     return ynotebook;
   }
 
@@ -207,16 +207,17 @@ export class YNotebook
    *
    * @param index: Position to insert the cells.
    * @param cells: Array of shared cells to insert.
+   * @param dirty: The dirty state to set.
    *
    * @returns The inserted cells.
    */
   insertCells(
     index: number,
     cells: SharedCell.Cell[],
-    setDirty: boolean = true
+    dirty: boolean = true
   ): YBaseCell<nbformat.IBaseCellMetadata>[] {
     const yCells = cells.map(c => {
-      const cell = createCell(c, this);
+      const cell = createCell(c, this, dirty);
       this._ycellMapping.set(cell.ymodel, cell);
       return cell;
     });
@@ -228,9 +229,7 @@ export class YNotebook
       );
     });
 
-    if (setDirty) {
-      this.setDirty();
-    }
+    this.setDirty(dirty);
 
     return yCells;
   }
@@ -265,7 +264,7 @@ export class YNotebook
       );
     });
 
-    this.setDirty();
+    this.setDirty(true);
   }
 
   /**
@@ -282,16 +281,14 @@ export class YNotebook
    *
    * @param from: The start index of the range to remove (inclusive).
    * @param to: The end index of the range to remove (exclusive).
+   * @param dirty: The dirty state to set.
    */
-  deleteCellRange(from: number, to: number, setDirty: boolean = true): void {
+  deleteCellRange(from: number, to: number, dirty: boolean = true): void {
     // Cells will be removed from the mapping in the model event listener.
     this.transact(() => {
       this._ycells.delete(from, to - from);
     });
-
-    if (setDirty) {
-      this.setDirty();
-    }
+    this.setDirty(dirty);
   }
 
   /**
@@ -386,7 +383,7 @@ export class YNotebook
           }
         });
 
-        this.setDirty();
+        this.setDirty(true);
       }
     }
   }
@@ -412,7 +409,7 @@ export class YNotebook
       }
     });
 
-    this.setDirty();
+    this.setDirty(true);
   }
 
   /**
@@ -430,7 +427,7 @@ export class YNotebook
    * @param value The notebook
    */
   setSource(value: JSONValue): void {
-    this.fromJSON(value as nbformat.INotebookContent);
+    this.fromJSON(value as nbformat.INotebookContent, false);
   }
 
   /**
@@ -438,7 +435,7 @@ export class YNotebook
    *
    * @param value The notebook
    */
-  fromJSON(value: nbformat.INotebookContent): void {
+  fromJSON(value: nbformat.INotebookContent, dirty: boolean = true): void {
     this.transact(() => {
       this.nbformat = value.nbformat;
       this.nbformat_minor = value.nbformat_minor;
@@ -465,8 +462,8 @@ export class YNotebook
         }
         return cell;
       });
-      this.insertCells(this.cells.length, ycells, false);
-      this.deleteCellRange(0, this.cells.length, false);
+      this.insertCells(this.cells.length, ycells, dirty);
+      this.deleteCellRange(0, this.cells.length, dirty);
     });
   }
 

--- a/javascript/test/ycell.spec.ts
+++ b/javascript/test/ycell.spec.ts
@@ -259,7 +259,7 @@ describe('@jupyter/ydoc', () => {
         collapsed: true,
         editable: false,
         name: 'cell-name0',
-        test: "foo"
+        test: 'foo'
       };
       cell.setMetadata(metadata0, false);
       expect(notebook.dirty).toBe(false);
@@ -267,7 +267,7 @@ describe('@jupyter/ydoc', () => {
         collapsed: true,
         editable: false,
         name: 'cell-name1',
-        test: "bar"
+        test: 'bar'
       };
       cell.setMetadata(metadata1);
       expect(notebook.dirty).toBe(true);

--- a/javascript/test/ycell.spec.ts
+++ b/javascript/test/ycell.spec.ts
@@ -248,6 +248,33 @@ describe('@jupyter/ydoc', () => {
     });
   });
 
+  describe('#dirty', () => {
+    test('should set dirty to false if passed in setMetadata', () => {
+      const notebook = YNotebook.create();
+      const cell = notebook.addCell({ cell_type: 'code' });
+      expect(notebook.dirty).toBe(true);
+      notebook.dirty = false;
+      expect(notebook.dirty).toBe(false);
+      const metadata0 = {
+        collapsed: true,
+        editable: false,
+        name: 'cell-name0',
+        test: "foo"
+      };
+      cell.setMetadata(metadata0, false);
+      expect(notebook.dirty).toBe(false);
+      const metadata1 = {
+        collapsed: true,
+        editable: false,
+        name: 'cell-name1',
+        test: "bar"
+      };
+      cell.setMetadata(metadata1);
+      expect(notebook.dirty).toBe(true);
+      notebook.dispose();
+    });
+  });
+
   describe('#undo', () => {
     test('should undo source change', () => {
       const codeCell = YCodeCell.create();

--- a/javascript/test/yfile.spec.ts
+++ b/javascript/test/yfile.spec.ts
@@ -9,6 +9,7 @@ describe('@jupyter/ydoc', () => {
       test('should create a document without arguments', () => {
         const file = new YFile();
         expect(file.source.length).toBe(0);
+        expect(file.dirty).toBe(false);
         file.dispose();
       });
     });
@@ -30,9 +31,10 @@ describe('@jupyter/ydoc', () => {
         const file = new YFile();
 
         const source = 'foo';
-        file.setSource(source);
+        file.source = source;
 
         expect(file.source).toEqual(source);
+        expect(file.dirty).toEqual(false);
         file.dispose();
       });
 
@@ -40,9 +42,9 @@ describe('@jupyter/ydoc', () => {
         const file = new YFile();
 
         const source = 'foo';
-        file.setSource(source);
+        file.source = source;
 
-        expect(file.getSource()).toEqual(source);
+        expect(file.source).toEqual(source);
         file.dispose();
       });
 
@@ -50,11 +52,13 @@ describe('@jupyter/ydoc', () => {
         const file = new YFile();
 
         const source = 'fooo bar';
-        file.setSource(source);
+        file.source = source;
         expect(file.source).toBe(source);
+        expect(file.dirty).toEqual(false);
 
         file.updateSource(3, 5, '/');
         expect(file.source).toBe('foo/bar');
+        expect(file.dirty).toEqual(true);
         file.dispose();
       });
 
@@ -67,7 +71,7 @@ describe('@jupyter/ydoc', () => {
           changes.push(c.sourceChange!);
         });
         const source = 'foo';
-        file.setSource(source);
+        file.source = source;
 
         expect(changes).toHaveLength(1);
         expect(changes).toEqual([
@@ -84,14 +88,14 @@ describe('@jupyter/ydoc', () => {
       test('should emit a delete source change', () => {
         const file = new YFile();
         const source = 'foo';
-        file.setSource(source);
+        file.source = source;
         expect(file.source).toBe(source);
 
         const changes: Delta<string>[] = [];
         file.changed.connect((_, c) => {
           changes.push(c.sourceChange!);
         });
-        file.setSource('');
+        file.source = '';
 
         expect(changes).toHaveLength(1);
         expect(changes).toEqual([
@@ -108,7 +112,7 @@ describe('@jupyter/ydoc', () => {
       test('should emit an update source change', () => {
         const file = new YFile();
         const source1 = 'foo';
-        file.setSource(source1);
+        file.source = source1;
         expect(file.source).toBe(source1);
 
         const changes: Delta<string>[] = [];
@@ -116,7 +120,7 @@ describe('@jupyter/ydoc', () => {
           changes.push(c.sourceChange!);
         });
         const source = 'bar';
-        file.setSource(source);
+        file.source = source;
 
         expect(changes).toHaveLength(1);
         expect(changes).toEqual([

--- a/javascript/test/ynotebook.spec.ts
+++ b/javascript/test/ynotebook.spec.ts
@@ -379,7 +379,7 @@ describe('@jupyter/ydoc', () => {
         });
         const codeCell = notebook.insertCell(0, { cell_type: 'code' });
 
-        expect(changes).toHaveLength(1);
+        expect(changes).toHaveLength(2);
         expect(changes[0].cellsChange).toEqual([
           {
             insert: [codeCell]

--- a/javascript/test/ynotebook.spec.ts
+++ b/javascript/test/ynotebook.spec.ts
@@ -18,6 +18,7 @@ describe('@jupyter/ydoc', () => {
       test('should create a notebook without arguments', () => {
         const notebook = YNotebook.create();
         expect(notebook.cells.length).toBe(0);
+        expect(notebook.dirty).toBe(false);
         notebook.dispose();
       });
     });
@@ -40,6 +41,7 @@ describe('@jupyter/ydoc', () => {
         });
         expect(notebook.cells).toHaveLength(1);
         expect(notebook.cells[0].toJSON()).toEqual(cell);
+        expect(notebook.dirty).toBe(false);
         notebook.dispose();
       });
 
@@ -62,6 +64,7 @@ describe('@jupyter/ydoc', () => {
         expect(notebook.nbformat).toEqual(1);
         expect(notebook.nbformat_minor).toEqual(0);
         expect(notebook.metadata).toEqual(metadata);
+        expect(notebook.dirty).toBe(false);
         notebook.dispose();
       });
     });
@@ -92,6 +95,7 @@ describe('@jupyter/ydoc', () => {
         notebook.setMetadata(metadata);
 
         expect(notebook.metadata).toEqual(metadata);
+        expect(notebook.dirty).toBe(true);
         notebook.dispose();
       });
 
@@ -173,12 +177,15 @@ describe('@jupyter/ydoc', () => {
           display_name: 'python',
           name: 'python'
         };
+        expect(notebook.dirty).toBe(false);
         notebook.setMetadata(metadata);
         {
           const metadata = notebook.getMetadata();
           expect(metadata.kernelspec!.name).toBe('python');
           expect(metadata.orig_nbformat).toBe(1);
         }
+        expect(notebook.dirty).toBe(true);
+        notebook.dirty = false;
         notebook.updateMetadata({
           orig_nbformat: 2
         });
@@ -187,6 +194,7 @@ describe('@jupyter/ydoc', () => {
           expect(metadata.kernelspec!.name).toBe('python');
           expect(metadata.orig_nbformat).toBe(2);
         }
+        expect(notebook.dirty).toBe(true);
         notebook.dispose();
       });
 
@@ -351,22 +359,37 @@ describe('@jupyter/ydoc', () => {
     describe('#insertCell', () => {
       test('should insert a cell', () => {
         const notebook = YNotebook.create();
+        expect(notebook.dirty).toBe(false);
         notebook.insertCell(0, { cell_type: 'code' });
         expect(notebook.cells.length).toBe(1);
+        expect(notebook.dirty).toBe(true);
         notebook.dispose();
       });
       test('should set cell source', () => {
         const notebook = YNotebook.create();
+        expect(notebook.dirty).toBe(false);
         const codeCell = notebook.insertCell(0, { cell_type: 'code' });
+        expect(notebook.dirty).toBe(true);
+        notebook.dirty = false;
+        expect(notebook.dirty).toBe(false);
         codeCell.setSource('test');
+        expect(notebook.dirty).toBe(true);
         expect(notebook.cells[0].getSource()).toBe('test');
         notebook.dispose();
       });
       test('should update source', () => {
         const notebook = YNotebook.create();
+        expect(notebook.dirty).toBe(false);
         const codeCell = notebook.insertCell(0, { cell_type: 'code' });
+        expect(notebook.dirty).toBe(true);
+        notebook.dirty = false;
+        expect(notebook.dirty).toBe(false);
         codeCell.setSource('test');
+        expect(notebook.dirty).toBe(true);
+        notebook.dirty = false;
+        expect(notebook.dirty).toBe(false);
         codeCell.updateSource(0, 0, 'hello');
+        expect(notebook.dirty).toBe(true);
         expect(codeCell.getSource()).toBe('hellotest');
         notebook.dispose();
       });
@@ -380,7 +403,14 @@ describe('@jupyter/ydoc', () => {
         const codeCell = notebook.insertCell(0, { cell_type: 'code' });
 
         expect(changes).toHaveLength(2);
-        expect(changes[0].cellsChange).toEqual([
+        expect(changes[0].stateChange).toEqual([
+          {
+            name: "dirty",
+            oldValue: false,
+            newValue: true,
+          }
+        ]);
+        expect(changes[1].cellsChange).toEqual([
           {
             insert: [codeCell]
           }
@@ -493,6 +523,28 @@ describe('@jupyter/ydoc', () => {
 
     describe('#undo', () => {
       describe('globally', () => {
+        test('should set dirty after undoing a change', () => {
+          const notebook = YNotebook.create();
+          expect(notebook.dirty).toBe(false);
+          notebook.addCell({ cell_type: 'code' });
+          expect(notebook.dirty).toBe(true);
+          notebook.dirty = false;
+          expect(notebook.dirty).toBe(false);
+
+          notebook.undo();
+
+          expect(notebook.dirty).toBe(true);
+        });
+
+        test('should not set dirty after undoing no change', () => {
+          const notebook = YNotebook.create();
+          expect(notebook.dirty).toBe(false);
+
+          notebook.undo();
+
+          expect(notebook.dirty).toBe(false);
+        });
+
         test('should undo cell addition', () => {
           const notebook = YNotebook.create();
           notebook.addCell({ cell_type: 'code' });

--- a/javascript/test/ynotebook.spec.ts
+++ b/javascript/test/ynotebook.spec.ts
@@ -405,9 +405,9 @@ describe('@jupyter/ydoc', () => {
         expect(changes).toHaveLength(2);
         expect(changes[0].stateChange).toEqual([
           {
-            name: "dirty",
+            name: 'dirty',
             oldValue: false,
-            newValue: true,
+            newValue: true
           }
         ]);
         expect(changes[1].cellsChange).toEqual([


### PR DESCRIPTION
This PR is the same as https://github.com/jupyter-server/jupyter_ydoc/pull/406 but on the `4.x` branch.

See https://github.com/jupyterlab/jupyterlab/pull/18739.

This PR systematically sets the document dirty state after each change, except for `setSource` which is called at document initialization.