### PR TITLE
Allow `observe()` callbacks to receive the `pycrdt` transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,6 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
-## Unreleased
-
-### Enhancements made
-
-- `observe()` callbacks may now opt into receiving the underlying pycrdt transaction
-  as a 3rd argument: `callback(part, events, txn)`. The original 2-argument form
-  `callback(part, events)` continues to work unchanged. Applies to `YNotebook`,
-  `YUnicode`, `YBlob` (and `YFile` via inheritance).
-
 ## 4.0.0a0
 
 ([Full Changelog](https://github.com/jupyter-server/jupyter_ydoc/compare/@jupyter/ydoc@3.4.1...844604ab538528c5f54d5e0cc4e185bb8ee050d3))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## Unreleased
+
+### Enhancements made
+
+- `observe()` callbacks may now opt into receiving the underlying pycrdt transaction
+  as a 3rd argument: `callback(part, events, txn)`. The original 2-argument form
+  `callback(part, events)` continues to work unchanged. Applies to `YNotebook`,
+  `YUnicode`, `YBlob` (and `YFile` via inheritance).
+
 ## 4.0.0a0
 
 ([Full Changelog](https://github.com/jupyter-server/jupyter_ydoc/compare/@jupyter/ydoc@3.4.1...844604ab538528c5f54d5e0cc4e185bb8ee050d3))

--- a/jupyter_ydoc/ybasedoc.py
+++ b/jupyter_ydoc/ybasedoc.py
@@ -3,10 +3,38 @@
 
 from abc import ABC, abstractmethod
 from collections.abc import Callable
-from typing import Any
+from functools import partial
+from inspect import signature
+from typing import Any, Union
 
 from anyio import lowlevel
 from pycrdt import Awareness, Doc, Map, Subscription, UndoManager
+
+TwoArgObserveCallback = Callable[[str, Any], None]
+ThreeArgObserveCallback = Callable[[str, Any, Any], None]
+ObserveCallback = Union[TwoArgObserveCallback, ThreeArgObserveCallback]
+
+
+def _observe_callback_param_count(callback: ObserveCallback) -> int:
+    param_count = len(signature(callback).parameters)
+    if param_count not in (2, 3):
+        raise TypeError(
+            "observe() callback must accept (part, events) or (part, events, txn); "
+            f"got {param_count} parameters."
+        )
+    return param_count
+
+
+def _make_observe_adapter(
+    callback: ObserveCallback, part: str, param_count: int
+) -> Callable[..., None]:
+    if param_count == 2:
+        return partial(callback, part)
+
+    def adapter(events: Any, txn: Any) -> None:
+        callback(part, events, txn)
+
+    return adapter
 
 
 class YBaseDoc(ABC):
@@ -203,12 +231,14 @@ class YBaseDoc(ABC):
         self.set(value)
 
     @abstractmethod
-    def observe(self, callback: Callable[[str, Any], None]) -> None:
+    def observe(self, callback: ObserveCallback) -> None:
         """
         Subscribes to document changes.
 
         :param callback: Callback that will be called when the document changes.
-        :type callback: Callable[[str, Any], None]
+            May accept either ``(part, events)`` or ``(part, events, txn)``. With the
+            3-argument form, the underlying pycrdt :class:`ReadTransaction` is forwarded.
+        :type callback: Callable[[str, Any], None] | Callable[[str, Any, Any], None]
         """
 
     def unobserve(self) -> None:

--- a/jupyter_ydoc/ybasedoc.py
+++ b/jupyter_ydoc/ybasedoc.py
@@ -26,7 +26,7 @@ def _observe_callback_param_count(callback: ObserveCallback) -> int:
 
 
 def _make_observe_adapter(
-    callback: ObserveCallback, part: str, param_count: int
+    callback: Callable[..., None], part: str, param_count: int
 ) -> Callable[..., None]:
     if param_count == 2:
         return partial(callback, part)

--- a/jupyter_ydoc/ybasedoc.py
+++ b/jupyter_ydoc/ybasedoc.py
@@ -5,14 +5,14 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from functools import partial
 from inspect import signature
-from typing import Any, Union
+from typing import Any
 
 from anyio import lowlevel
 from pycrdt import Awareness, Doc, Map, Subscription, UndoManager
 
 TwoArgObserveCallback = Callable[[str, Any], None]
 ThreeArgObserveCallback = Callable[[str, Any, Any], None]
-ObserveCallback = Union[TwoArgObserveCallback, ThreeArgObserveCallback]
+ObserveCallback = TwoArgObserveCallback | ThreeArgObserveCallback
 
 
 def _observe_callback_param_count(callback: ObserveCallback) -> int:

--- a/jupyter_ydoc/yblob.py
+++ b/jupyter_ydoc/yblob.py
@@ -1,13 +1,14 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from collections.abc import Callable
-from functools import partial
-from typing import Any
-
 from pycrdt import Awareness, Doc, Map
 
-from .ybasedoc import YBaseDoc
+from .ybasedoc import (
+    ObserveCallback,
+    YBaseDoc,
+    _make_observe_adapter,
+    _observe_callback_param_count,
+)
 
 
 class YBlob(YBaseDoc):
@@ -70,13 +71,20 @@ class YBlob(YBaseDoc):
 
         self._ysource["bytes"] = value
 
-    def observe(self, callback: Callable[[str, Any], None]) -> None:
+    def observe(self, callback: ObserveCallback) -> None:
         """
         Subscribes to document changes.
 
         :param callback: Callback that will be called when the document changes.
-        :type callback: Callable[[str, Any], None]
+            May accept either ``(part, events)`` or ``(part, events, txn)``. With the
+            3-argument form, the underlying pycrdt :class:`ReadTransaction` is forwarded.
+        :type callback: Callable[[str, Any], None] | Callable[[str, Any, Any], None]
         """
         self.unobserve()
-        self._subscriptions[self._ystate] = self._ystate.observe(partial(callback, "state"))
-        self._subscriptions[self._ysource] = self._ysource.observe(partial(callback, "source"))
+        param_count = _observe_callback_param_count(callback)
+        self._subscriptions[self._ystate] = self._ystate.observe(
+            _make_observe_adapter(callback, "state", param_count)
+        )
+        self._subscriptions[self._ysource] = self._ysource.observe(
+            _make_observe_adapter(callback, "source", param_count)
+        )

--- a/jupyter_ydoc/ynotebook.py
+++ b/jupyter_ydoc/ynotebook.py
@@ -3,8 +3,7 @@
 
 import copy
 import warnings
-from collections.abc import Callable, Iterator
-from functools import partial
+from collections.abc import Iterator
 from typing import Any
 from uuid import uuid4
 
@@ -12,7 +11,12 @@ from anyio import lowlevel
 from pycrdt import Array, Awareness, Doc, Map, Text
 
 from .utils import cast_all
-from .ybasedoc import YBaseDoc
+from .ybasedoc import (
+    ObserveCallback,
+    YBaseDoc,
+    _make_observe_adapter,
+    _observe_callback_param_count,
+)
 
 # The default major version of the notebook format.
 NBFORMAT_MAJOR_VERSION = 4
@@ -437,17 +441,26 @@ class YNotebook(YBaseDoc):
         for val in self._set(value):
             await lowlevel.checkpoint()
 
-    def observe(self, callback: Callable[[str, Any], None]) -> None:
+    def observe(self, callback: ObserveCallback) -> None:
         """
         Subscribes to document changes.
 
         :param callback: Callback that will be called when the document changes.
-        :type callback: Callable[[str, Any], None]
+            May accept either ``(part, events)`` or ``(part, events, txn)``. With the
+            3-argument form, the underlying pycrdt :class:`ReadTransaction` is forwarded.
+        :type callback: Callable[[str, Any], None] | Callable[[str, Any, Any], None]
         """
         self.unobserve()
-        self._subscriptions[self._ystate] = self._ystate.observe(partial(callback, "state"))
-        self._subscriptions[self._ymeta] = self._ymeta.observe_deep(partial(callback, "meta"))
-        self._subscriptions[self._ycells] = self._ycells.observe_deep(partial(callback, "cells"))
+        param_count = _observe_callback_param_count(callback)
+        self._subscriptions[self._ystate] = self._ystate.observe(
+            _make_observe_adapter(callback, "state", param_count)
+        )
+        self._subscriptions[self._ymeta] = self._ymeta.observe_deep(
+            _make_observe_adapter(callback, "meta", param_count)
+        )
+        self._subscriptions[self._ycells] = self._ycells.observe_deep(
+            _make_observe_adapter(callback, "cells", param_count)
+        )
 
     def _update_cell(self, old_cell: dict, new_cell: dict, old_ycell: Map) -> bool:
         if old_cell == new_cell:

--- a/jupyter_ydoc/yunicode.py
+++ b/jupyter_ydoc/yunicode.py
@@ -1,14 +1,16 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from collections.abc import Callable
 from difflib import SequenceMatcher
-from functools import partial
-from typing import Any
 
 from pycrdt import Awareness, Doc, Text
 
-from .ybasedoc import YBaseDoc
+from .ybasedoc import (
+    ObserveCallback,
+    YBaseDoc,
+    _make_observe_adapter,
+    _observe_callback_param_count,
+)
 
 # Heuristic threshold as recommended in difflib documentation
 SIMILARITY_THREESHOLD = 0.6
@@ -150,16 +152,23 @@ class YUnicode(YBaseDoc):
                 if value:
                     self._ysource += value
 
-    def observe(self, callback: Callable[[str, Any], None]) -> None:
+    def observe(self, callback: ObserveCallback) -> None:
         """
         Subscribes to document changes.
 
         :param callback: Callback that will be called when the document changes.
-        :type callback: Callable[[str, Any], None]
+            May accept either ``(part, events)`` or ``(part, events, txn)``. With the
+            3-argument form, the underlying pycrdt :class:`ReadTransaction` is forwarded.
+        :type callback: Callable[[str, Any], None] | Callable[[str, Any, Any], None]
         """
         self.unobserve()
-        self._subscriptions[self._ystate] = self._ystate.observe(partial(callback, "state"))
-        self._subscriptions[self._ysource] = self._ysource.observe(partial(callback, "source"))
+        param_count = _observe_callback_param_count(callback)
+        self._subscriptions[self._ystate] = self._ystate.observe(
+            _make_observe_adapter(callback, "state", param_count)
+        )
+        self._subscriptions[self._ysource] = self._ysource.observe(
+            _make_observe_adapter(callback, "source", param_count)
+        )
 
 
 def _is_utf8_continuation_byte(byte: int) -> bool:

--- a/tests/test_yblob.py
+++ b/tests/test_yblob.py
@@ -27,3 +27,19 @@ def test_set_no_op_if_unchanged():
 
     # No changes should be observed at all
     assert changes == []
+
+
+def test_observe_with_transaction():
+    blob = YBlob()
+    received = []
+
+    def cb(part, events, txn):
+        received.append((part, txn.origin))
+
+    blob.observe(cb)
+
+    with blob.ydoc.transaction(origin="my-origin"):
+        blob.set(b"hello")
+
+    assert received
+    assert any(part == "source" and origin == "my-origin" for part, origin in received)

--- a/tests/test_ynotebook.py
+++ b/tests/test_ynotebook.py
@@ -506,3 +506,19 @@ async def test_async_notebook():
     # check that the max blocking time is at least 20 times
     # smaller than if we did a blocking get:
     assert max_blocking_time < get_time / 20
+
+
+def test_observe_with_transaction():
+    nb = YNotebook()
+    received = []
+
+    def cb(part, events, txn):
+        received.append((part, txn.origin))
+
+    nb.observe(cb)
+
+    with nb.ydoc.transaction(origin="my-origin"):
+        nb.append_cell(make_code_cell("print('hello')"))
+
+    assert received
+    assert any(part == "cells" and origin == "my-origin" for part, origin in received)

--- a/tests/test_yunicode.py
+++ b/tests/test_yunicode.py
@@ -322,3 +322,19 @@ def test_multibyte_unicode(initial, updated, granular):
 
     assert len(source_events[0].delta) >= expected_min_delta_length
     assert text.get() == updated
+
+
+def test_observe_with_transaction():
+    text = YUnicode()
+    received = []
+
+    def cb(part, events, txn):
+        received.append((part, txn.origin))
+
+    text.observe(cb)
+
+    with text.ydoc.transaction(origin="my-origin"):
+        text.set("hello")
+
+    assert received
+    assert any(part == "source" and origin == "my-origin" for part, origin in received)


### PR DESCRIPTION
## Summary

`YBaseDoc.observe()` (and the `YNotebook` / `YUnicode` / `YBlob` overrides) currently wrap the user callback as `functools.partial(callback, "<part>")` before handing it to pycrdt's `observe()` / `observe_deep()`. pycrdt uses `inspect.signature(...).parameters` to decide how many args to pass; the partial reports arity 1, so pycrdt only forwards the events list — the transaction is silently dropped.

That makes it impossible for downstream consumers to do things like:

```python
def on_change(part, events, txn):
    if txn.origin == self._my_origin:
        return  # ignore self-originated edits
    ...
```

even though pycrdt and the underlying yrs layer both support it natively.

This PR makes `observe()` arity-aware, mirroring pycrdt's own pattern. The user callback may now be either:

- `callback(part, events)` — unchanged legacy behaviour, or
- `callback(part, events, txn)` — the pycrdt `ReadTransaction` is forwarded so callers can inspect `txn.origin` etc.

A small shared helper in `ybasedoc.py` (`_observe_callback_param_count` + `_make_observe_adapter`) keeps the three subclasses aligned. The 2-arg adapter is still `partial(callback, part)`; the 3-arg adapter is a 2-param closure that pycrdt's introspection sees as wanting both `events` and `txn`.

## Why this matters

Today, downstream projects that want `txn.origin` inside an `observe` callback have had to fork pycrdt to bolt the transaction onto event objects. The actual fix lives here, not in pycrdt — pycrdt already plumbs the transaction through; `jupyter_ydoc` is the layer that strips it.

## Changes

- `jupyter_ydoc/ybasedoc.py` — add `ObserveCallback` type alias, `_observe_callback_param_count`, `_make_observe_adapter`; widen the abstract signature.
- `jupyter_ydoc/ynotebook.py`, `yunicode.py`, `yblob.py` — use the shared adapter for each part. (`yfile.py` inherits.)
- `tests/test_y{notebook,unicode,blob}.py` — one new test per doc type that writes inside `ydoc.transaction(origin="my-origin")` with a 3-arg callback and asserts `txn.origin` is reachable.
- `CHANGELOG.md` — entry under a new `Unreleased` section.

## Backwards compatibility

Fully preserved. Every existing 2-arg callback in the test suite (and there are many) keeps working with no changes. An invalid arity (1 or 4+) raises `TypeError` at `observe()` time, which is friendlier than the silent miswiring the partial path produced before.

## Test plan

- [x] `pytest tests/ --ignore=tests/test_pycrdt_yjs.py` — 63 passed, 1 deselected (`test_set_fast_path_for_large_initial_content`, a 1 GB-string test that times out in resource-constrained CI envs; unrelated to this change).
- [x] `pytest tests/test_pycrdt_yjs.py` — 3 passed.
- [x] Manual proof against stock `pycrdt==0.12.50`:

```python
from jupyter_ydoc import YNotebook
from pycrdt import Doc

doc = Doc()
nb = YNotebook(doc)
seen = []
def watch(part, events, txn):
    seen.append(("self" if txn.origin == "agent-42" else "foreign", part))
nb.observe(watch)

with doc.transaction(origin="agent-42"):
    nb.append_cell({"cell_type": "code", "source": "self-write"})
with doc.transaction(origin="someone-else"):
    nb.append_cell({"cell_type": "code", "source": "foreign-write"})

print(seen)  # [('self', 'cells'), ('foreign', 'cells')]
```

## Notes for reviewers

- Type hint on the 3rd arg is `Any` rather than `pycrdt.ReadTransaction` to avoid a hard import dependency on a class whose location has shifted between pycrdt versions; the docstring names the concrete type.
- Happy to also backport to a `3.x` maintenance branch if a 3.4.2 patch release is desired — let me know.