### PR TITLE
Remove dirty argument in methods: follow up #406

### DIFF
--- a/javascript/src/api.ts
+++ b/javascript/src/api.ts
@@ -317,15 +317,10 @@ export interface ISharedNotebook extends ISharedDocument {
    *
    * @param index Position to insert the cells.
    * @param cells Array of shared cells to insert.
-   * @param dirty The dirty state to set.
    *
    * @returns The inserted cells.
    */
-  insertCells(
-    index: number,
-    cells: Array<SharedCell.Cell>,
-    dirty?: boolean
-  ): ISharedCell[];
+  insertCells(index: number, cells: Array<SharedCell.Cell>): ISharedCell[];
 
   /**
    * Move a cell.
@@ -357,18 +352,15 @@ export interface ISharedNotebook extends ISharedDocument {
    * @param from: The start index of the range to remove (inclusive).
    *
    * @param to: The end index of the range to remove (exclusive).
-   *
-   * @param dirty: The dirty state to set.
    */
-  deleteCellRange(from: number, to: number, dirty?: boolean): void;
+  deleteCellRange(from: number, to: number): void;
 
   /**
    * Override the notebook with a JSON-serialized document.
    *
    * @param value The notebook
-   * @param dirty The dirty state to set.
    */
-  fromJSON(value: nbformat.INotebookContent, dirty?: boolean): void;
+  fromJSON(value: nbformat.INotebookContent): void;
 
   /**
    * Serialize the model to JSON.

--- a/javascript/src/ycell.ts
+++ b/javascript/src/ycell.ts
@@ -61,8 +61,7 @@ export const createCellModelFromSharedType = (
  */
 export const createCell = (
   cell: SharedCell.Cell,
-  notebook?: YNotebook,
-  dirty: boolean = true
+  notebook?: YNotebook
 ): YCodeCell | YMarkdownCell | YRawCell => {
   const ymodel = new Y.Map();
   const ysource = new Y.Text();
@@ -77,7 +76,7 @@ export const createCell = (
     case 'markdown': {
       ycell = new YMarkdownCell(ymodel, ysource, { notebook }, ymetadata);
       if (cell.attachments != null) {
-        ycell.setAttachments(cell.attachments as nbformat.IAttachments, dirty);
+        ycell.setAttachments(cell.attachments as nbformat.IAttachments);
       }
       break;
     }
@@ -94,9 +93,9 @@ export const createCell = (
         ymetadata
       );
       const cCell = cell as Partial<nbformat.ICodeCell>;
-      ycell.setExecutionCount(cCell.execution_count ?? null, dirty);
+      ycell.setExecutionCount(cCell.execution_count ?? null);
       if (cCell.outputs) {
-        ycell.setOutputs(cCell.outputs, dirty);
+        ycell.setOutputs(cCell.outputs);
       }
       break;
     }
@@ -104,19 +103,18 @@ export const createCell = (
       // raw
       ycell = new YRawCell(ymodel, ysource, { notebook }, ymetadata);
       if (cell.attachments) {
-        ycell.setAttachments(cell.attachments as nbformat.IAttachments, dirty);
+        ycell.setAttachments(cell.attachments as nbformat.IAttachments);
       }
       break;
     }
   }
 
   if (cell.metadata != null) {
-    ycell.setMetadata(cell.metadata, dirty);
+    ycell.setMetadata(cell.metadata);
   }
   if (cell.source != null) {
     ycell.setSource(
-      typeof cell.source === 'string' ? cell.source : cell.source.join(''),
-      dirty
+      typeof cell.source === 'string' ? cell.source : cell.source.join('')
     );
   }
   return ycell;
@@ -409,14 +407,13 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
    * Sets cell's source.
    *
    * @param value: New source.
-   * @param dirty: The dirty state to set.
    */
-  setSource(value: string, dirty: boolean = true): void {
+  setSource(value: string): void {
     this.transact(() => {
       this.ysource.delete(0, this.ysource.length);
       this.ysource.insert(0, value);
     });
-    this.dirty = dirty;
+    this.dirty = true;
     // @todo Do we need proper replace semantic? This leads to issues in editor bindings because they don't switch source.
     // this.ymodel.set('source', new Y.Text(value));
   }
@@ -505,16 +502,12 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
    *
    * @param metadata Cell's metadata key or cell's metadata.
    * @param value Metadata value
-   * @param dirty The dirty state to set.
    */
   setMetadata(metadata: Partial<Metadata>): void;
-  setMetadata(metadata: Partial<Metadata>, dirty: boolean): void;
   setMetadata(metadata: string, value: PartialJSONValue): void;
-  setMetadata(metadata: string, value: PartialJSONValue, dirty: boolean): void;
   setMetadata(
     metadata: Partial<Metadata> | string,
-    value?: PartialJSONValue | boolean,
-    dirty?: boolean
+    value?: PartialJSONValue
   ): void {
     if (typeof metadata === 'string') {
       if (typeof value === 'undefined') {
@@ -552,7 +545,7 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
           }
         }
       }, false);
-      this.dirty = dirty ?? true;
+      this.dirty = true;
     } else {
       const clone = JSONExt.deepCopy(metadata) as any;
       if (clone.collapsed != null) {
@@ -567,7 +560,7 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
             this._ymetadata.set(key, value);
           }
         }, false);
-        this.dirty = (value as boolean | undefined) ?? true;
+        this.dirty = true;
       }
     }
   }
@@ -768,7 +761,7 @@ export class YCodeCell
     this.setExecutionCount(count);
   }
 
-  setExecutionCount(count: number | null, dirty: boolean = true) {
+  setExecutionCount(count: number | null) {
     // Do not use `this.execution_count`. When initializing the
     // cell, we need to set execution_count to `null` if we compare
     // using `this.execution_count` it will return `null` and we will
@@ -777,7 +770,7 @@ export class YCodeCell
       this.transact(() => {
         this.ymodel.set('execution_count', count);
       }, false);
-      this.dirty = dirty;
+      this.dirty = true;
     }
   }
 
@@ -843,13 +836,13 @@ export class YCodeCell
   /**
    * Replace all outputs.
    */
-  setOutputs(outputs: Array<nbformat.IOutput>, dirty: boolean = true): void {
+  setOutputs(outputs: Array<nbformat.IOutput>): void {
     this.transact(() => {
       this._youtputs.delete(0, this._youtputs.length);
       const newOutputs = this.createOutputs(outputs);
       this._youtputs.insert(0, newOutputs);
     }, false);
-    this.dirty = dirty;
+    this.dirty = true;
   }
 
   /**
@@ -1021,12 +1014,8 @@ class YAttachmentCell
    * Sets the cell attachments
    *
    * @param attachments: The cell attachments.
-   * @param dirty: The dirty state to set.
    */
-  setAttachments(
-    attachments: nbformat.IAttachments | undefined,
-    dirty: boolean = true
-  ): void {
+  setAttachments(attachments: nbformat.IAttachments | undefined): void {
     this.transact(() => {
       if (attachments == null) {
         this.ymodel.delete('attachments');
@@ -1034,7 +1023,7 @@ class YAttachmentCell
         this.ymodel.set('attachments', attachments);
       }
     }, false);
-    this.dirty = dirty;
+    this.dirty = true;
   }
 
   /**

--- a/javascript/src/ynotebook.ts
+++ b/javascript/src/ynotebook.ts
@@ -89,7 +89,7 @@ export class YNotebook
       metadata: options.data?.metadata ?? {}
     };
 
-    ynotebook.fromJSON(data, false);
+    ynotebook.setSource(data as JSONValue);
     return ynotebook;
   }
 
@@ -207,17 +207,15 @@ export class YNotebook
    *
    * @param index: Position to insert the cells.
    * @param cells: Array of shared cells to insert.
-   * @param dirty: The dirty state to set.
    *
    * @returns The inserted cells.
    */
   insertCells(
     index: number,
-    cells: SharedCell.Cell[],
-    dirty: boolean = true
+    cells: SharedCell.Cell[]
   ): YBaseCell<nbformat.IBaseCellMetadata>[] {
     const yCells = cells.map(c => {
-      const cell = createCell(c, this, dirty);
+      const cell = createCell(c, this);
       this._ycellMapping.set(cell.ymodel, cell);
       return cell;
     });
@@ -229,7 +227,7 @@ export class YNotebook
       );
     });
 
-    this.dirty = dirty;
+    this.dirty = true;
 
     return yCells;
   }
@@ -281,14 +279,13 @@ export class YNotebook
    *
    * @param from: The start index of the range to remove (inclusive).
    * @param to: The end index of the range to remove (exclusive).
-   * @param dirty: The dirty state to set.
    */
-  deleteCellRange(from: number, to: number, dirty: boolean = true): void {
+  deleteCellRange(from: number, to: number): void {
     // Cells will be removed from the mapping in the model event listener.
     this.transact(() => {
       this._ycells.delete(from, to - from);
     });
-    this.dirty = dirty;
+    this.dirty = true;
   }
 
   /**
@@ -427,7 +424,8 @@ export class YNotebook
    * @param value The notebook
    */
   setSource(value: JSONValue): void {
-    this.fromJSON(value as nbformat.INotebookContent, false);
+    this.fromJSON(value as nbformat.INotebookContent);
+    this.dirty = false;
   }
 
   /**
@@ -435,7 +433,7 @@ export class YNotebook
    *
    * @param value The notebook
    */
-  fromJSON(value: nbformat.INotebookContent, dirty: boolean = true): void {
+  fromJSON(value: nbformat.INotebookContent): void {
     this.transact(() => {
       this.nbformat = value.nbformat;
       this.nbformat_minor = value.nbformat_minor;
@@ -462,8 +460,8 @@ export class YNotebook
         }
         return cell;
       });
-      this.insertCells(this.cells.length, ycells, dirty);
-      this.deleteCellRange(0, this.cells.length, dirty);
+      this.insertCells(this.cells.length, ycells);
+      this.deleteCellRange(0, this.cells.length);
     });
   }
 

--- a/javascript/test/ycell.spec.ts
+++ b/javascript/test/ycell.spec.ts
@@ -249,27 +249,18 @@ describe('@jupyter/ydoc', () => {
   });
 
   describe('#dirty', () => {
-    test('should set dirty to false if passed in setMetadata', () => {
+    test('should set dirty when cell metadata changes', () => {
       const notebook = YNotebook.create();
       const cell = notebook.addCell({ cell_type: 'code' });
-      expect(notebook.dirty).toBe(true);
       notebook.dirty = false;
       expect(notebook.dirty).toBe(false);
-      const metadata0 = {
+      const metadata = {
         collapsed: true,
         editable: false,
-        name: 'cell-name0',
+        name: 'cell-name',
         test: 'foo'
       };
-      cell.setMetadata(metadata0, false);
-      expect(notebook.dirty).toBe(false);
-      const metadata1 = {
-        collapsed: true,
-        editable: false,
-        name: 'cell-name1',
-        test: 'bar'
-      };
-      cell.setMetadata(metadata1);
+      cell.setMetadata(metadata);
       expect(notebook.dirty).toBe(true);
       notebook.dispose();
     });


### PR DESCRIPTION
This PR removes the `dirty` argument from `ynotebook` methods.
This argument was there to allow making change without updating the `dirty` state (e.g. initialization).

I think it is cleaner to set the state as dirty as for any change, and set `dirty` to `false` when the initialization is over:
- avoid updating the API (currently this API change is only in alpha release)
- looks correct to me, as the shared document is dirty during initialization, as it doesn't yet reflect the content on disk

