### PR TITLE
Stream notebook loading with delayed large outputs

### DIFF
--- a/jupyter_ydoc/ybasedoc.py
+++ b/jupyter_ydoc/ybasedoc.py
@@ -202,7 +202,7 @@ class YBaseDoc(ABC):
         await lowlevel.checkpoint()
         self.set(value)
 
-    async def aset_progressively(self, value: Any, **kwargs: Any) -> None:
+    async def aset_progressively(self, value: Any) -> None:
         """
         Sets the content of the document progressively, if supported by the document.
 

--- a/jupyter_ydoc/ybasedoc.py
+++ b/jupyter_ydoc/ybasedoc.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from typing import Any
 
-from anyio import lowlevel
+from anyio import Event, lowlevel
 from pycrdt import Awareness, Doc, Map, Subscription, UndoManager
 
 
@@ -202,7 +202,11 @@ class YBaseDoc(ABC):
         await lowlevel.checkpoint()
         self.set(value)
 
-    async def aset_progressively(self, value: Any) -> None:
+    async def aset_progressively(
+        self,
+        value: Any,
+        initialized: Event | None = None,
+    ) -> None:
         """
         Sets the content of the document progressively, if supported by the document.
 
@@ -210,6 +214,8 @@ class YBaseDoc(ABC):
         custom progressive behavior still support the generic API.
         """
         await self.aset(value)
+        if initialized is not None:
+            initialized.set()
 
     @abstractmethod
     def observe(self, callback: Callable[[str, Any], None]) -> None:

--- a/jupyter_ydoc/ybasedoc.py
+++ b/jupyter_ydoc/ybasedoc.py
@@ -202,6 +202,15 @@ class YBaseDoc(ABC):
         await lowlevel.checkpoint()
         self.set(value)
 
+    async def aset_progressively(self, value: Any, **kwargs: Any) -> None:
+        """
+        Sets the content of the document progressively, if supported by the document.
+
+        The default implementation falls back to `aset`, so document types without
+        custom progressive behavior still support the generic API.
+        """
+        await self.aset(value)
+
     @abstractmethod
     def observe(self, callback: Callable[[str, Any], None]) -> None:
         """

--- a/jupyter_ydoc/ybasedoc.py
+++ b/jupyter_ydoc/ybasedoc.py
@@ -1,11 +1,12 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import asyncio
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from typing import Any
 
-from anyio import Event, lowlevel
+import anyio
 from pycrdt import Awareness, Doc, Map, Subscription, UndoManager
 
 
@@ -188,7 +189,7 @@ class YBaseDoc(ABC):
         :return: Document's content.
         :rtype: Any
         """
-        await lowlevel.checkpoint()
+        await anyio.lowlevel.checkpoint()
         return self.get()
 
     async def aset(self, value: Any) -> None:
@@ -199,13 +200,13 @@ class YBaseDoc(ABC):
         :param value: The content of the document.
         :type value: Any
         """
-        await lowlevel.checkpoint()
+        await anyio.lowlevel.checkpoint()
         self.set(value)
 
     async def aset_progressively(
         self,
         value: Any,
-        initialized: Event | None = None,
+        initialized: anyio.Event | asyncio.Event | None = None,
     ) -> None:
         """
         Sets the content of the document progressively, if supported by the document.

--- a/jupyter_ydoc/ynotebook.py
+++ b/jupyter_ydoc/ynotebook.py
@@ -2,6 +2,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 import copy
+import json
 import warnings
 from collections.abc import Callable, Iterator
 from functools import partial
@@ -178,19 +179,51 @@ class YNotebook(YBaseDoc):
                 del cell["attachments"]
         elif cell_type == "code":
             outputs = cell.get("outputs", [])
-            for idx, output in enumerate(outputs):
-                if output.get("output_type") == "stream":
-                    text = output.get("text", "")
-                    if isinstance(text, str):
-                        ytext = Text(text)
-                    else:
-                        ytext = Text("".join(text))
-                    output["text"] = ytext
-                outputs[idx] = Map(output)
-            cell["outputs"] = Array(outputs)
+            cell["outputs"] = Array(self._create_youtputs(outputs, copy_outputs=False))
             cell["execution_state"] = "idle"
 
         return Map(cell)
+
+    def _create_youtputs(
+        self, outputs: list[dict[str, Any]], copy_outputs: bool = True
+    ) -> list[Map]:
+        if copy_outputs:
+            outputs = copy.deepcopy(outputs)
+        youtputs = []
+        for output in outputs:
+            if output.get("output_type") == "stream":
+                text = output.get("text", "")
+                if isinstance(text, str):
+                    ytext = Text(text)
+                else:
+                    ytext = Text("".join(text))
+                output["text"] = ytext
+            youtputs.append(Map(output))
+        return youtputs
+
+    def _set_ycell_outputs(self, ycell: Map, outputs: list[dict[str, Any]]) -> None:
+        if not isinstance(ycell.get("outputs"), Array):
+            ycell["outputs"] = Array()
+        youtputs: Array = ycell["outputs"]
+        youtputs.clear()
+        youtputs.extend(self._create_youtputs(outputs))
+
+    def _outputs_should_be_delayed(
+        self, outputs: list[dict[str, Any]], delay_outputs_above_mb: float | None
+    ) -> bool:
+        if delay_outputs_above_mb is None or not outputs:
+            return False
+
+        max_size = delay_outputs_above_mb * 1024 * 1024
+        output_size = 0
+        for chunk in json.JSONEncoder(
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).iterencode(outputs):
+            output_size += len(chunk.encode("utf-8"))
+            if output_size > max_size:
+                return True
+        return False
 
     def set_ycell(self, index: int, ycell: Map) -> None:
         """
@@ -290,10 +323,11 @@ class YNotebook(YBaseDoc):
         # runs it until completion and the latter inserts async checkpoints
         # in order to not block the event loop for too long for notebooks
         # with a lot of cells.
-        for _ in self._set(value):
-            pass
+        with self._ydoc.transaction():
+            for _ in self._set(value):
+                pass
 
-    def _set(self, value: dict) -> Iterator[None]:
+    def _set(self, value: dict, delay_outputs_above_mb: float | None = None) -> Iterator[None]:
         nb_without_cells = {key: value[key] for key in value.keys() if key != "cells"}
         nb = copy.deepcopy(nb_without_cells)
         cast_all(nb, int, float)  # Yjs expects numbers to be floating numbers
@@ -320,95 +354,125 @@ class YNotebook(YBaseDoc):
             if cell_id is not None and cell_id not in old_ycells_by_id:
                 old_ycells_by_id[cell_id] = ycell
 
-        with self._ydoc.transaction():
-            new_cell_list: list[dict] = []
-            retained_cells = set()
+        for key in [k for k in self._ystate.keys() if k not in ("dirty", "path", "document_id")]:
+            del self._ystate[key]
 
-            # Determine cells to be retained
-            for new_cell in new_cells:
+        nbformat_major = nb.get("nbformat", NBFORMAT_MAJOR_VERSION)
+        nbformat_minor = nb.get("nbformat_minor", NBFORMAT_MINOR_VERSION)
+
+        if meta.get("nbformat") != nbformat_major:
+            self._ymeta["nbformat"] = nbformat_major
+
+        if meta.get("nbformat_minor") != nbformat_minor:
+            self._ymeta["nbformat_minor"] = nbformat_minor
+
+        old_metadata = meta.get("metadata")
+        metadata = nb.get("metadata", {})
+
+        if metadata != old_metadata:
+            metadata.setdefault("language_info", {"name": ""})
+            metadata.setdefault("kernelspec", {"name": "", "display_name": ""})
+            self._ymeta["metadata"] = Map(metadata)
+
+        new_cell_list: list[dict] = []
+        delayed_outputs: list[list[dict[str, Any]] | None] = []
+        retained_cells = set()
+
+        # Determine cells to be retained
+        for new_cell in new_cells:
+            yield
+            cell_id = new_cell.get("id")
+            if cell_id and (old_ycell := old_ycells_by_id.get(cell_id)):
+                old_cell = self._cell_to_py(old_ycell, meta)
+                if old_cell == new_cell:
+                    new_cell_list.append(new_cell)
+                    delayed_outputs.append(None)
+                    retained_cells.add(cell_id)
+                    continue
+                prepared_cell, outputs = self._without_delayed_outputs(
+                    new_cell, delay_outputs_above_mb
+                )
+                updated_granularly = self._update_cell(
+                    old_cell=old_cell, new_cell=prepared_cell, old_ycell=old_ycell
+                )
+
+                if updated_granularly:
+                    new_cell_list.append(prepared_cell)
+                    delayed_outputs.append(outputs)
+                    retained_cells.add(cell_id)
+                    continue
+                new_cell_list.append(prepared_cell)
+                delayed_outputs.append(outputs)
+                continue
+            # New cell
+            new_cell, outputs = self._without_delayed_outputs(new_cell, delay_outputs_above_mb)
+            new_cell_list.append(new_cell)
+            delayed_outputs.append(outputs)
+
+        # First delete all non-retained cells and duplicates
+        if not retained_cells:
+            # fast path if no cells were retained
+            self._ycells.clear()
+        else:
+            index = 0
+            seen: set[str] = set()
+            while True:
                 yield
-                cell_id = new_cell.get("id")
-                if cell_id and (old_ycell := old_ycells_by_id.get(cell_id)):
-                    old_cell = self._cell_to_py(old_ycell, meta)
-                    updated_granularly = self._update_cell(
-                        old_cell=old_cell, new_cell=new_cell, old_ycell=old_ycell
-                    )
+                if index == len(self._ycells):
+                    break
+                old_ycell = self._ycells[index]
+                cell_id = old_ycell.get("id")
+                if cell_id is None or cell_id not in retained_cells or cell_id in seen:
+                    self._ycells.pop(index)
+                else:
+                    seen.add(cell_id)
+                    index += 1
 
-                    if updated_granularly:
-                        new_cell_list.append(new_cell)
-                        retained_cells.add(cell_id)
-                        continue
-                # New or changed cell
-                new_cell_list.append(new_cell)
+        # Now reorder/insert cells to match new_cell_list
+        for index, new_cell in enumerate(new_cell_list):
+            yield
+            new_id = new_cell.get("id")
 
-            # First delete all non-retained cells and duplicates
-            if not retained_cells:
-                # fast path if no cells were retained
-                self._ycells.clear()
-            else:
-                index = 0
-                seen: set[str] = set()
-                while True:
+            # Fast path: correct cell already at this position
+            if len(self._ycells) > index and self._ycells[index].get("id") == new_id:
+                continue
+
+            # Retained cell: find and move it into position
+            if new_id is not None and new_id in retained_cells:
+                # Linear scan to find the cell (O(n) per retained cell)
+                for cur in range(index + 1, len(self._ycells)):
                     yield
-                    if index == len(self._ycells):
+                    if self._ycells[cur].get("id") == new_id:
+                        # Use delete+recreate instead of move() for yjs 13.x compatibility
+                        # (yjs 13.x doesn't support the move operation that pycrdt generates)
+                        del self._ycells[cur]
+                        self._ycells.insert(index, self.create_ycell(new_cell))
                         break
-                    old_ycell = self._ycells[index]
-                    cell_id = old_ycell.get("id")
-                    if cell_id is None or cell_id not in retained_cells or cell_id in seen:
-                        self._ycells.pop(index)
-                    else:
-                        seen.add(cell_id)
-                        index += 1
+                continue
 
-            # Now reorder/insert cells to match new_cell_list
-            for index, new_cell in enumerate(new_cell_list):
-                yield
-                new_id = new_cell.get("id")
+            # New cell: insert at position
+            self._ycells.insert(index, self.create_ycell(new_cell))
 
-                # Fast path: correct cell already at this position
-                if len(self._ycells) > index and self._ycells[index].get("id") == new_id:
-                    continue
+        # Remove any extra cells at the end
+        del self._ycells[len(new_cell_list) :]
 
-                # Retained cell: find and move it into position
-                if new_id is not None and new_id in retained_cells:
-                    # Linear scan to find the cell (O(n) per retained cell)
-                    for cur in range(index + 1, len(self._ycells)):
-                        yield
-                        if self._ycells[cur].get("id") == new_id:
-                            # Use delete+recreate instead of move() for yjs 13.x compatibility
-                            # (yjs 13.x doesn't support the move operation that pycrdt generates)
-                            del self._ycells[cur]
-                            self._ycells.insert(index, self.create_ycell(new_cell))
-                            break
-                    continue
+        for index, outputs in enumerate(delayed_outputs):
+            if outputs is None:
+                continue
+            yield
+            self._set_ycell_outputs(self._ycells[index], outputs)
 
-                # New cell: insert at position
-                self._ycells.insert(index, self.create_ycell(new_cell))
-
-            # Remove any extra cells at the end
-            del self._ycells[len(new_cell_list) :]
-
-            for key in [
-                k for k in self._ystate.keys() if k not in ("dirty", "path", "document_id")
-            ]:
-                del self._ystate[key]
-
-            nbformat_major = nb.get("nbformat", NBFORMAT_MAJOR_VERSION)
-            nbformat_minor = nb.get("nbformat_minor", NBFORMAT_MINOR_VERSION)
-
-            if meta.get("nbformat") != nbformat_major:
-                self._ymeta["nbformat"] = nbformat_major
-
-            if meta.get("nbformat_minor") != nbformat_minor:
-                self._ymeta["nbformat_minor"] = nbformat_minor
-
-            old_metadata = meta.get("metadata")
-            metadata = nb.get("metadata", {})
-
-            if metadata != old_metadata:
-                metadata.setdefault("language_info", {"name": ""})
-                metadata.setdefault("kernelspec", {"name": "", "display_name": ""})
-                self._ymeta["metadata"] = Map(metadata)
+    def _without_delayed_outputs(
+        self, cell: dict, delay_outputs_above_mb: float | None
+    ) -> tuple[dict, list[dict[str, Any]] | None]:
+        outputs = cell.get("outputs", [])
+        if cell.get("cell_type") == "code" and self._outputs_should_be_delayed(
+            outputs, delay_outputs_above_mb
+        ):
+            first_pass_cell = copy.deepcopy(cell)
+            first_pass_cell["outputs"] = []
+            return first_pass_cell, outputs
+        return cell, None
 
     async def aget(self, deduplicate: bool = True) -> dict:
         """
@@ -426,16 +490,45 @@ class YNotebook(YBaseDoc):
         assert val is not None
         return val
 
-    async def aset(self, value: dict) -> None:
+    async def aset(
+        self,
+        value: dict,
+        progressive: bool = False,
+        delay_outputs_above_mb: float | None = None,
+    ) -> None:
         """
         Sets the content of the document, yielding to the event loop often enough
         to not block it for too long.
 
         :param value: The content of the document.
         :type value: Dict
+        :param progressive: Whether to progressively update the notebook in
+                            multiple transactions.
+        :type progressive: bool
+        :param delay_outputs_above_mb: Size in MB above which code cell outputs
+                                       should be delayed during progressive loading.
+        :type delay_outputs_above_mb: float, optional
         """
-        for val in self._set(value):
-            await lowlevel.checkpoint()
+        if delay_outputs_above_mb is not None and delay_outputs_above_mb < 0:
+            msg = "delay_outputs_above_mb must be greater than or equal to 0"
+            raise ValueError(msg)
+
+        if progressive:
+            gen = self._set(value, delay_outputs_above_mb)
+            while True:
+                done = False
+                async with self._ydoc.transaction():
+                    try:
+                        next(gen)
+                    except StopIteration:
+                        done = True
+                await lowlevel.checkpoint()
+                if done:
+                    break
+        else:
+            with self._ydoc.transaction():
+                for _ in self._set(value):
+                    await lowlevel.checkpoint()
 
     def observe(self, callback: Callable[[str, Any], None]) -> None:
         """
@@ -474,12 +567,22 @@ class YNotebook(YBaseDoc):
                     return False
 
                 if key in _CELL_KEY_TYPE_MAP:
-                    kind = _CELL_KEY_TYPE_MAP[key]
-
-                    if not isinstance(old_ycell[key], kind):
+                    if not isinstance(old_ycell.get(key), _CELL_KEY_TYPE_MAP[key]):
                         # if our assumptions about types do not hold, fall back to hard update
                         return False
 
+        for key in added_keys:
+            if key in _CELL_KEY_TYPE_MAP:
+                # we hard-reload cells when keys that require nested types get added
+                # to allow the frontend to connect observers; this could be changed
+                # in the future, once frontends learn how to observe all changes
+                return False
+
+        for key in shared_keys:
+            if old_cell[key] != new_cell[key]:
+                value = new_cell[key]
+                if key in _CELL_KEY_TYPE_MAP:
+                    kind = _CELL_KEY_TYPE_MAP[key]
                     if kind == Text:
                         old_text: Text = old_ycell[key]
                         old_text.clear()
@@ -499,11 +602,5 @@ class YNotebook(YBaseDoc):
             del old_ycell[key]
 
         for key in added_keys:
-            if key in _CELL_KEY_TYPE_MAP:
-                # we hard-reload cells when keys that require nested types get added
-                # to allow the frontend to connect observers; this could be changed
-                # in the future, once frontends learn how to observe all changes
-                return False
-            else:
-                old_ycell[key] = new_cell[key]
+            old_ycell[key] = new_cell[key]
         return True

--- a/jupyter_ydoc/ynotebook.py
+++ b/jupyter_ydoc/ynotebook.py
@@ -9,7 +9,7 @@ from functools import partial
 from typing import Any
 from uuid import uuid4
 
-from anyio import lowlevel
+from anyio import Event, lowlevel
 from pycrdt import Array, Awareness, Doc, Map, Text
 
 from .utils import cast_all
@@ -327,36 +327,12 @@ class YNotebook(YBaseDoc):
             for _ in self._set(value):
                 pass
 
-    def _set(self, value: dict, delay_outputs_above_mb: float | None = None) -> Iterator[None]:
+    def _set(self, value: dict, delay_outputs_above_mb: float | None = None) -> Iterator[bool]:
         nb_without_cells = {key: value[key] for key in value.keys() if key != "cells"}
         nb = copy.deepcopy(nb_without_cells)
         cast_all(nb, int, float)  # Yjs expects numbers to be floating numbers
 
         meta = self._ymeta.to_py()
-
-        new_cells = value["cells"] or [
-            {
-                "cell_type": "code",
-                "execution_count": None,
-                # auto-created empty code cell without outputs ought be trusted
-                "metadata": {"trusted": True},
-                "outputs": [],
-                "source": "",
-                "id": str(uuid4()),
-            }
-        ]
-        # Build dict of old cells by ID, keeping only the first occurrence of each ID
-        # to handle the case where the stored doc already has duplicate IDs.
-        old_ycells_by_id: dict[str, Map] = {}
-        for ycell in self._ycells:
-            yield
-            cell_id = ycell.get("id")
-            if cell_id is not None and cell_id not in old_ycells_by_id:
-                old_ycells_by_id[cell_id] = ycell
-
-        for key in [k for k in self._ystate.keys() if k not in ("dirty", "path", "document_id")]:
-            del self._ystate[key]
-
         nbformat_major = nb.get("nbformat", NBFORMAT_MAJOR_VERSION)
         nbformat_minor = nb.get("nbformat_minor", NBFORMAT_MINOR_VERSION)
 
@@ -374,13 +350,38 @@ class YNotebook(YBaseDoc):
             metadata.setdefault("kernelspec", {"name": "", "display_name": ""})
             self._ymeta["metadata"] = Map(metadata)
 
+        yield True  # notify that the notebook is initialized
+
+        new_cells = value["cells"] or [
+            {
+                "cell_type": "code",
+                "execution_count": None,
+                # auto-created empty code cell without outputs ought be trusted
+                "metadata": {"trusted": True},
+                "outputs": [],
+                "source": "",
+                "id": str(uuid4()),
+            }
+        ]
+        # Build dict of old cells by ID, keeping only the first occurrence of each ID
+        # to handle the case where the stored doc already has duplicate IDs.
+        old_ycells_by_id: dict[str, Map] = {}
+        for ycell in self._ycells:
+            yield False
+            cell_id = ycell.get("id")
+            if cell_id is not None and cell_id not in old_ycells_by_id:
+                old_ycells_by_id[cell_id] = ycell
+
+        for key in [k for k in self._ystate.keys() if k not in ("dirty", "path", "document_id")]:
+            del self._ystate[key]
+
         new_cell_list: list[dict] = []
         delayed_outputs: list[list[dict[str, Any]] | None] = []
         retained_cells = set()
 
         # Determine cells to be retained
         for new_cell in new_cells:
-            yield
+            yield False
             cell_id = new_cell.get("id")
             if cell_id and (old_ycell := old_ycells_by_id.get(cell_id)):
                 old_cell = self._cell_to_py(old_ycell, meta)
@@ -417,7 +418,7 @@ class YNotebook(YBaseDoc):
             index = 0
             seen: set[str] = set()
             while True:
-                yield
+                yield False
                 if index == len(self._ycells):
                     break
                 old_ycell = self._ycells[index]
@@ -430,7 +431,7 @@ class YNotebook(YBaseDoc):
 
         # Now reorder/insert cells to match new_cell_list
         for index, new_cell in enumerate(new_cell_list):
-            yield
+            yield False
             new_id = new_cell.get("id")
 
             # Fast path: correct cell already at this position
@@ -441,7 +442,7 @@ class YNotebook(YBaseDoc):
             if new_id is not None and new_id in retained_cells:
                 # Linear scan to find the cell (O(n) per retained cell)
                 for cur in range(index + 1, len(self._ycells)):
-                    yield
+                    yield False
                     if self._ycells[cur].get("id") == new_id:
                         # Use delete+recreate instead of move() for yjs 13.x compatibility
                         # (yjs 13.x doesn't support the move operation that pycrdt generates)
@@ -459,7 +460,7 @@ class YNotebook(YBaseDoc):
         for index, outputs in enumerate(delayed_outputs):
             if outputs is None:
                 continue
-            yield
+            yield False
             self._set_ycell_outputs(self._ycells[index], outputs)
 
     def _without_delayed_outputs(
@@ -505,6 +506,7 @@ class YNotebook(YBaseDoc):
     async def aset_progressively(
         self,
         value: dict,
+        initialized: Event | None = None,
         delay_outputs_above_mb: float | None = None,
     ) -> None:
         """
@@ -515,6 +517,8 @@ class YNotebook(YBaseDoc):
         :param delay_outputs_above_mb: Size in MB above which code cell outputs
                                        should be delayed during progressive loading.
         :type delay_outputs_above_mb: float, optional
+        :param initialized: An optional event to set when the notebook metada has been set.
+        :type value: anyio.Event
         """
         if delay_outputs_above_mb is not None and delay_outputs_above_mb < 0:
             msg = "delay_outputs_above_mb must be greater than or equal to 0"
@@ -525,7 +529,8 @@ class YNotebook(YBaseDoc):
             done = False
             async with self._ydoc.transaction():
                 try:
-                    next(gen)
+                    if next(gen) and initialized is not None:
+                        initialized.set()
                 except StopIteration:
                     done = True
             await lowlevel.checkpoint()

--- a/jupyter_ydoc/ynotebook.py
+++ b/jupyter_ydoc/ynotebook.py
@@ -1,6 +1,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import asyncio
 import copy
 import json
 import warnings
@@ -9,7 +10,7 @@ from functools import partial
 from typing import Any
 from uuid import uuid4
 
-from anyio import Event, lowlevel
+import anyio
 from pycrdt import Array, Awareness, Doc, Map, Text
 
 from .utils import cast_all
@@ -486,7 +487,7 @@ class YNotebook(YBaseDoc):
         :rtype: Dict
         """
         for val in self._get(deduplicate):
-            await lowlevel.checkpoint()
+            await anyio.lowlevel.checkpoint()
 
         assert val is not None
         return val
@@ -501,12 +502,12 @@ class YNotebook(YBaseDoc):
         """
         with self._ydoc.transaction():
             for _ in self._set(value):
-                await lowlevel.checkpoint()
+                await anyio.lowlevel.checkpoint()
 
     async def aset_progressively(
         self,
         value: dict,
-        initialized: Event | None = None,
+        initialized: anyio.Event | asyncio.Event | None = None,
         delay_outputs_above_mb: float | None = None,
     ) -> None:
         """
@@ -518,7 +519,7 @@ class YNotebook(YBaseDoc):
                                        should be delayed during progressive loading.
         :type delay_outputs_above_mb: float, optional
         :param initialized: An optional event to set when the notebook metada has been set.
-        :type value: anyio.Event
+        :type value: Event
         """
         if delay_outputs_above_mb is not None and delay_outputs_above_mb < 0:
             msg = "delay_outputs_above_mb must be greater than or equal to 0"
@@ -533,7 +534,7 @@ class YNotebook(YBaseDoc):
                         initialized.set()
                 except StopIteration:
                     done = True
-            await lowlevel.checkpoint()
+            await anyio.lowlevel.checkpoint()
             if done:
                 break
 

--- a/jupyter_ydoc/ynotebook.py
+++ b/jupyter_ydoc/ynotebook.py
@@ -490,21 +490,28 @@ class YNotebook(YBaseDoc):
         assert val is not None
         return val
 
-    async def aset(
-        self,
-        value: dict,
-        progressive: bool = False,
-        delay_outputs_above_mb: float | None = None,
-    ) -> None:
+    async def aset(self, value: dict) -> None:
         """
         Sets the content of the document, yielding to the event loop often enough
         to not block it for too long.
 
         :param value: The content of the document.
         :type value: Dict
-        :param progressive: Whether to progressively update the notebook in
-                            multiple transactions.
-        :type progressive: bool
+        """
+        with self._ydoc.transaction():
+            for _ in self._set(value):
+                await lowlevel.checkpoint()
+
+    async def aset_progressively(
+        self,
+        value: dict,
+        delay_outputs_above_mb: float | None = None,
+    ) -> None:
+        """
+        Sets notebook content progressively in multiple transactions.
+
+        :param value: The content of the notebook.
+        :type value: Dict
         :param delay_outputs_above_mb: Size in MB above which code cell outputs
                                        should be delayed during progressive loading.
         :type delay_outputs_above_mb: float, optional
@@ -513,22 +520,17 @@ class YNotebook(YBaseDoc):
             msg = "delay_outputs_above_mb must be greater than or equal to 0"
             raise ValueError(msg)
 
-        if progressive:
-            gen = self._set(value, delay_outputs_above_mb)
-            while True:
-                done = False
-                async with self._ydoc.transaction():
-                    try:
-                        next(gen)
-                    except StopIteration:
-                        done = True
-                await lowlevel.checkpoint()
-                if done:
-                    break
-        else:
-            with self._ydoc.transaction():
-                for _ in self._set(value):
-                    await lowlevel.checkpoint()
+        gen = self._set(value, delay_outputs_above_mb)
+        while True:
+            done = False
+            async with self._ydoc.transaction():
+                try:
+                    next(gen)
+                except StopIteration:
+                    done = True
+            await lowlevel.checkpoint()
+            if done:
+                break
 
     def observe(self, callback: Callable[[str, Any], None]) -> None:
         """

--- a/tests/test_ydocs.py
+++ b/tests/test_ydocs.py
@@ -1,9 +1,37 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+from typing import Any
+
+import pytest
 from pycrdt import Awareness, Doc
 
 from jupyter_ydoc import YBlob, YNotebook
+from jupyter_ydoc.ybasedoc import YBaseDoc
+
+
+class SimpleYDoc(YBaseDoc):
+    def __init__(self):
+        super().__init__()
+        self.aset_values = []
+        self.value = None
+
+    @property
+    def version(self):
+        return "1.0.0"
+
+    def get(self):
+        return self.value
+
+    def set(self, value: Any) -> None:
+        self.value = value
+
+    async def aset(self, value: Any) -> None:
+        self.aset_values.append(value)
+        await super().aset(value)
+
+    def observe(self, callback):
+        pass
 
 
 def test_yblob():
@@ -23,6 +51,17 @@ def test_yblob():
     assert topic == "source"
     assert event.keys["bytes"]["oldValue"] == b"012"
     assert event.keys["bytes"]["newValue"] == b"345"
+
+
+@pytest.mark.anyio
+async def test_ybasedoc_aset_progressively_falls_back_to_aset_and_ignores_kwargs():
+    doc = SimpleYDoc()
+    value = {"cells": []}
+
+    await doc.aset_progressively(value, delay_outputs_above_mb=0)
+
+    assert doc.aset_values == [value]
+    assert doc.get() == value
 
 
 def test_ynotebook_undo_manager():

--- a/tests/test_ydocs.py
+++ b/tests/test_ydocs.py
@@ -1,6 +1,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import re
 from typing import Any
 
 import pytest
@@ -54,11 +55,20 @@ def test_yblob():
 
 
 @pytest.mark.anyio
-async def test_ybasedoc_aset_progressively_falls_back_to_aset_and_ignores_kwargs():
+async def test_ybasedoc_aset_progressively_falls_back_to_aset():
     doc = SimpleYDoc()
     value = {"cells": []}
 
-    await doc.aset_progressively(value, delay_outputs_above_mb=0)
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "YBaseDoc.aset_progressively() got an unexpected keyword argument "
+            "'delay_outputs_above_mb'"
+        ),
+    ):
+        await doc.aset_progressively(value, delay_outputs_above_mb=0)
+
+    await doc.aset_progressively(value)
 
     assert doc.aset_values == [value]
     assert doc.get() == value

--- a/tests/test_ynotebook.py
+++ b/tests/test_ynotebook.py
@@ -110,7 +110,7 @@ async def test_set_preserves_cells_with_insert_and_remove(do, progressive):
 
     nb.observe(record_changes)
     if progressive:
-        await nb.aset(model, progressive=True)
+        await nb.aset_progressively(model)
     else:
         await do(nb, "set", model)
 
@@ -150,7 +150,7 @@ async def test_set_preserves_cells_with_insert_and_remove(do, progressive):
         ]
 
 
-async def test_aset_progressive_populates_metadata_before_cells():
+async def test_aset_progressively_populates_metadata_before_cells():
     nb = YNotebook()
     changes = []
 
@@ -158,14 +158,13 @@ async def test_aset_progressive_populates_metadata_before_cells():
         changes.append((topic, event))
 
     nb.observe(record_changes)
-    await nb.aset(
+    await nb.aset_progressively(
         {
             "cells": [
                 make_code_cell("print('a')\n", id="cell-a"),
                 make_code_cell("print('b')\n", id="cell-b"),
             ]
-        },
-        progressive=True,
+        }
     )
 
     topics = [topic for topic, _ in changes]
@@ -177,7 +176,7 @@ async def test_aset_progressive_populates_metadata_before_cells():
     assert cell_events[1][0].delta == [{"retain": 1}, {"insert": [AnyInstanceOf(Map)]}]
 
 
-async def test_aset_progressive_delays_large_outputs_until_after_cells():
+async def test_aset_progressively_delays_large_outputs_until_after_cells():
     nb = YNotebook()
     outputs = [{"name": "stdout", "output_type": "stream", "text": "x" * 1024}]
     cell = make_code_cell("print('x')\n", id="cell-with-output")
@@ -189,9 +188,8 @@ async def test_aset_progressive_delays_large_outputs_until_after_cells():
             snapshots.append(nb.ycells.to_py())
 
     nb.observe(record_changes)
-    await nb.aset(
+    await nb.aset_progressively(
         {"cells": [cell]},
-        progressive=True,
         delay_outputs_above_mb=0,
     )
 
@@ -204,7 +202,7 @@ async def test_aset_progressive_delays_large_outputs_until_after_cells():
     assert model["cells"][0]["outputs"] == outputs
 
 
-async def test_aset_progressive_keeps_small_outputs_with_cell():
+async def test_aset_progressively_keeps_small_outputs_with_cell():
     nb = YNotebook()
     outputs = [{"name": "stdout", "output_type": "stream", "text": "x"}]
     cell = make_code_cell("print('x')\n", id="cell-with-small-output")
@@ -216,9 +214,8 @@ async def test_aset_progressive_keeps_small_outputs_with_cell():
             snapshots.append(nb.ycells.to_py())
 
     nb.observe(record_changes)
-    await nb.aset(
+    await nb.aset_progressively(
         {"cells": [cell]},
-        progressive=True,
         delay_outputs_above_mb=100,
     )
 
@@ -226,7 +223,7 @@ async def test_aset_progressive_keeps_small_outputs_with_cell():
     assert snapshots[0][0]["outputs"] == outputs
 
 
-async def test_aset_progressive_restores_delayed_outputs_after_hard_reload():
+async def test_aset_progressively_restores_delayed_outputs_after_hard_reload():
     nb = YNotebook()
     await nb.aset(
         {
@@ -245,9 +242,8 @@ async def test_aset_progressive_restores_delayed_outputs_after_hard_reload():
     cell = make_code_cell("print('x')\n", id="cell-to-reload")
     cell["outputs"] = outputs
 
-    await nb.aset(
+    await nb.aset_progressively(
         {"cells": [cell]},
-        progressive=True,
         delay_outputs_above_mb=0,
     )
 
@@ -256,7 +252,7 @@ async def test_aset_progressive_restores_delayed_outputs_after_hard_reload():
     assert model["cells"][0]["outputs"] == outputs
 
 
-async def test_aset_progressive_hard_reload_does_not_emit_partial_cell_update():
+async def test_aset_progressively_hard_reload_does_not_emit_partial_cell_update():
     nb = YNotebook()
     await nb.aset(
         {
@@ -280,7 +276,7 @@ async def test_aset_progressive_hard_reload_does_not_emit_partial_cell_update():
             cell_events.extend(event)
 
     nb.observe(record_changes)
-    await nb.aset(model, progressive=True)
+    await nb.aset_progressively(model)
 
     assert all(event.path == [] for event in cell_events)
     assert cell_events[0].delta == [{"retain": 1}, {"delete": 1}]
@@ -299,22 +295,17 @@ async def test_aset_non_progressive_does_not_delay_outputs():
             snapshots.append(nb.ycells.to_py())
 
     nb.observe(record_changes)
-    await nb.aset(
-        {"cells": [cell]},
-        progressive=False,
-        delay_outputs_above_mb=0,
-    )
+    await nb.aset({"cells": [cell]})
 
     assert len(snapshots) == 1
     assert snapshots[0][0]["outputs"] == outputs
 
 
-async def test_aset_rejects_negative_delay_outputs_threshold():
+async def test_aset_progressively_rejects_negative_delay_outputs_threshold():
     nb = YNotebook()
     with pytest.raises(ValueError, match="delay_outputs_above_mb"):
-        await nb.aset(
+        await nb.aset_progressively(
             {"cells": [make_code_cell("print('x')\n")]},
-            progressive=True,
             delay_outputs_above_mb=-1,
         )
 

--- a/tests/test_ynotebook.py
+++ b/tests/test_ynotebook.py
@@ -1,6 +1,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import json
 from time import monotonic
 from uuid import uuid4
 
@@ -68,7 +69,8 @@ async def test_set_populates_metadata(do):
     }
 
 
-async def test_set_preserves_cells_with_insert_and_remove(do):
+@pytest.mark.parametrize("progressive", [False, True], ids=["not progressive", "progressive"])
+async def test_set_preserves_cells_with_insert_and_remove(do, progressive):
     nb = YNotebook()
     await do(
         nb,
@@ -107,7 +109,10 @@ async def test_set_preserves_cells_with_insert_and_remove(do):
         changes.append((topic, event))
 
     nb.observe(record_changes)
-    await do(nb, "set", model)
+    if progressive:
+        await nb.aset(model, progressive=True)
+    else:
+        await do(nb, "set", model)
 
     assert nb.cell_number == 3
 
@@ -118,16 +123,215 @@ async def test_set_preserves_cells_with_insert_and_remove(do):
     # The middle cell should have a different source now
     assert str(nb.ycells[1]["source"]) == "print('x')\n"
 
-    # We should have one cell event
     cell_events = [e for t, e in changes if t == "cells"]
-    assert len(cell_events) == 1
-    event_transactions = cell_events[0]
-    assert len(event_transactions) == 1
-    assert event_transactions[0].delta == [
-        {"retain": 1},
-        {"delete": 1},
-        {"insert": [AnyInstanceOf(Map)]},
-    ]
+    if progressive:
+        assert len(cell_events) == 2
+        event_transactions = cell_events[0]
+        assert len(event_transactions) == 1
+        assert event_transactions[0].delta == [
+            {"retain": 1},
+            {"delete": 1},
+        ]
+        event_transactions = cell_events[1]
+        assert len(event_transactions) == 1
+        assert event_transactions[0].delta == [
+            {"retain": 1},
+            {"insert": [AnyInstanceOf(Map)]},
+        ]
+    else:
+        # We should have one cell event
+        assert len(cell_events) == 1
+        event_transactions = cell_events[0]
+        assert len(event_transactions) == 1
+        assert event_transactions[0].delta == [
+            {"retain": 1},
+            {"delete": 1},
+            {"insert": [AnyInstanceOf(Map)]},
+        ]
+
+
+async def test_aset_progressive_populates_metadata_before_cells():
+    nb = YNotebook()
+    changes = []
+
+    def record_changes(topic, event):
+        changes.append((topic, event))
+
+    nb.observe(record_changes)
+    await nb.aset(
+        {
+            "cells": [
+                make_code_cell("print('a')\n", id="cell-a"),
+                make_code_cell("print('b')\n", id="cell-b"),
+            ]
+        },
+        progressive=True,
+    )
+
+    topics = [topic for topic, _ in changes]
+    assert topics[0] == "meta"
+
+    cell_events = [event for topic, event in changes if topic == "cells"]
+    assert len(cell_events) == 2
+    assert cell_events[0][0].delta == [{"insert": [AnyInstanceOf(Map)]}]
+    assert cell_events[1][0].delta == [{"retain": 1}, {"insert": [AnyInstanceOf(Map)]}]
+
+
+async def test_aset_progressive_delays_large_outputs_until_after_cells():
+    nb = YNotebook()
+    outputs = [{"name": "stdout", "output_type": "stream", "text": "x" * 1024}]
+    cell = make_code_cell("print('x')\n", id="cell-with-output")
+    cell["outputs"] = outputs
+    snapshots = []
+
+    def record_changes(topic, event):
+        if topic == "cells":
+            snapshots.append(nb.ycells.to_py())
+
+    nb.observe(record_changes)
+    await nb.aset(
+        {"cells": [cell]},
+        progressive=True,
+        delay_outputs_above_mb=0,
+    )
+
+    assert len(snapshots) == 2
+    assert snapshots[0][0]["outputs"] == []
+    assert snapshots[1][0]["outputs"] == outputs
+    assert nb.ycells[0]["outputs"][0]["text"].to_py() == outputs[0]["text"]
+
+    model = await nb.aget()
+    assert model["cells"][0]["outputs"] == outputs
+
+
+async def test_aset_progressive_keeps_small_outputs_with_cell():
+    nb = YNotebook()
+    outputs = [{"name": "stdout", "output_type": "stream", "text": "x"}]
+    cell = make_code_cell("print('x')\n", id="cell-with-small-output")
+    cell["outputs"] = outputs
+    snapshots = []
+
+    def record_changes(topic, event):
+        if topic == "cells":
+            snapshots.append(nb.ycells.to_py())
+
+    nb.observe(record_changes)
+    await nb.aset(
+        {"cells": [cell]},
+        progressive=True,
+        delay_outputs_above_mb=100,
+    )
+
+    assert len(snapshots) == 1
+    assert snapshots[0][0]["outputs"] == outputs
+
+
+async def test_aset_progressive_restores_delayed_outputs_after_hard_reload():
+    nb = YNotebook()
+    await nb.aset(
+        {
+            "cells": [
+                {
+                    "id": "cell-to-reload",
+                    "cell_type": "markdown",
+                    "source": "old",
+                    "metadata": {},
+                }
+            ]
+        }
+    )
+
+    outputs = [{"name": "stdout", "output_type": "stream", "text": "x" * 1024}]
+    cell = make_code_cell("print('x')\n", id="cell-to-reload")
+    cell["outputs"] = outputs
+
+    await nb.aset(
+        {"cells": [cell]},
+        progressive=True,
+        delay_outputs_above_mb=0,
+    )
+
+    model = await nb.aget()
+    assert model["cells"][0]["cell_type"] == "code"
+    assert model["cells"][0]["outputs"] == outputs
+
+
+async def test_aset_progressive_hard_reload_does_not_emit_partial_cell_update():
+    nb = YNotebook()
+    await nb.aset(
+        {
+            "cells": [
+                make_code_cell("print('keep')\n", id="keep-cell"),
+                {
+                    "id": "cell-to-reload",
+                    "cell_type": "markdown",
+                    "source": "old",
+                    "metadata": {},
+                },
+            ]
+        }
+    )
+    model = await nb.aget()
+    model["cells"][1] = make_code_cell("print('new')\n", id="cell-to-reload")
+    cell_events = []
+
+    def record_changes(topic, event):
+        if topic == "cells":
+            cell_events.extend(event)
+
+    nb.observe(record_changes)
+    await nb.aset(model, progressive=True)
+
+    assert all(event.path == [] for event in cell_events)
+    assert cell_events[0].delta == [{"retain": 1}, {"delete": 1}]
+    assert cell_events[1].delta == [{"retain": 1}, {"insert": [AnyInstanceOf(Map)]}]
+
+
+async def test_aset_non_progressive_does_not_delay_outputs():
+    nb = YNotebook()
+    outputs = [{"name": "stdout", "output_type": "stream", "text": "x" * 1024}]
+    cell = make_code_cell("print('x')\n", id="cell-with-output")
+    cell["outputs"] = outputs
+    snapshots = []
+
+    def record_changes(topic, event):
+        if topic == "cells":
+            snapshots.append(nb.ycells.to_py())
+
+    nb.observe(record_changes)
+    await nb.aset(
+        {"cells": [cell]},
+        progressive=False,
+        delay_outputs_above_mb=0,
+    )
+
+    assert len(snapshots) == 1
+    assert snapshots[0][0]["outputs"] == outputs
+
+
+async def test_aset_rejects_negative_delay_outputs_threshold():
+    nb = YNotebook()
+    with pytest.raises(ValueError, match="delay_outputs_above_mb"):
+        await nb.aset(
+            {"cells": [make_code_cell("print('x')\n")]},
+            progressive=True,
+            delay_outputs_above_mb=-1,
+        )
+
+
+def test_outputs_should_be_delayed_uses_configured_mb_threshold():
+    nb = YNotebook()
+    outputs = [{"name": "stdout", "output_type": "stream", "text": "x"}]
+    output_size = len(
+        json.dumps(
+            outputs,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    )
+
+    assert not nb._outputs_should_be_delayed(outputs, output_size / 1024 / 1024)
+    assert nb._outputs_should_be_delayed(outputs, (output_size - 1) / 1024 / 1024)
 
 
 @mark.parametrize(


### PR DESCRIPTION
Contains the setup in this repo for https://github.com/jupyterlab/jupyter-collaboration/issues/552

Adds progressive notebook updates so metadata and cells can be synced before large outputs, with an optional `delay_outputs_above_mb` threshold for deferring big code-cell outputs until after cells are loaded. Keeps non-progressive loading unchanged, preserves full notebook contents after delayed restoration, and adds regression coverage for hard-reload output restoration and progressive event ordering.

This PR is built on top of https://github.com/jupyter-server/jupyter_ydoc/pull/393, including the discussion points.