### PR TITLE
Add optional `finish` event to `aset_progressively`

### DIFF
--- a/jupyter_ydoc/ybasedoc.py
+++ b/jupyter_ydoc/ybasedoc.py
@@ -208,6 +208,7 @@ class YBaseDoc(ABC):
         value: Any,
         initialized: anyio.Event | asyncio.Event | None = None,
         finish: anyio.Event | asyncio.Event | None = None,
+        **kwargs: Any,
     ) -> None:
         """
         Sets the content of the document progressively, if supported by the document.

--- a/jupyter_ydoc/ybasedoc.py
+++ b/jupyter_ydoc/ybasedoc.py
@@ -207,6 +207,7 @@ class YBaseDoc(ABC):
         self,
         value: Any,
         initialized: anyio.Event | asyncio.Event | None = None,
+        finish: anyio.Event | asyncio.Event | None = None,
     ) -> None:
         """
         Sets the content of the document progressively, if supported by the document.

--- a/jupyter_ydoc/ynotebook.py
+++ b/jupyter_ydoc/ynotebook.py
@@ -508,6 +508,7 @@ class YNotebook(YBaseDoc):
         self,
         value: dict,
         initialized: anyio.Event | asyncio.Event | None = None,
+        finish: anyio.Event | asyncio.Event | None = None,
         delay_outputs_above_mb: float | None = None,
     ) -> None:
         """
@@ -519,6 +520,8 @@ class YNotebook(YBaseDoc):
                                        should be delayed during progressive loading.
         :type delay_outputs_above_mb: float, optional
         :param initialized: An optional event to set when the notebook metada has been set.
+        :type value: Event
+        :param finish: An optional event set when to start setting the notebook cells.
         :type value: Event
         """
         if delay_outputs_above_mb is not None and delay_outputs_above_mb < 0:
@@ -532,9 +535,10 @@ class YNotebook(YBaseDoc):
                 try:
                     if next(gen) and initialized is not None:
                         initialized.set()
+                        if finish is not None:
+                            await finish.wait()
                 except StopIteration:
                     done = True
-            await anyio.lowlevel.checkpoint()
             if done:
                 break
 

--- a/jupyter_ydoc/ynotebook.py
+++ b/jupyter_ydoc/ynotebook.py
@@ -510,6 +510,7 @@ class YNotebook(YBaseDoc):
         initialized: anyio.Event | asyncio.Event | None = None,
         finish: anyio.Event | asyncio.Event | None = None,
         delay_outputs_above_mb: float | None = None,
+        **kwargs: Any,
     ) -> None:
         """
         Sets notebook content progressively in multiple transactions.
@@ -539,6 +540,7 @@ class YNotebook(YBaseDoc):
                             await finish.wait()
                 except StopIteration:
                     done = True
+            await anyio.lowlevel.checkpoint()
             if done:
                 break
 

--- a/tests/test_ydocs.py
+++ b/tests/test_ydocs.py
@@ -1,7 +1,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import re
 from typing import Any
 
 import pytest

--- a/tests/test_ydocs.py
+++ b/tests/test_ydocs.py
@@ -59,15 +59,6 @@ async def test_ybasedoc_aset_progressively_falls_back_to_aset():
     doc = SimpleYDoc()
     value = {"cells": []}
 
-    with pytest.raises(
-        TypeError,
-        match=re.escape(
-            "YBaseDoc.aset_progressively() got an unexpected keyword argument "
-            "'delay_outputs_above_mb'"
-        ),
-    ):
-        await doc.aset_progressively(value, delay_outputs_above_mb=0)
-
     await doc.aset_progressively(value)
 
     assert doc.aset_values == [value]


### PR DESCRIPTION
This is needed in https://github.com/jupyterlab/jupyter-collaboration/pull/607.
With that the `initialized` and `finish` events allow to populate a shared document in two phases:
- when the document is initialized (e.g. a notebook has metadata), it sets `initialized` so that the room can be marked as ready to sync.
- when the room has subscribed to the document changes, it sets `finish` so that the rest of the document is populated (e.g. the notebook cells are inserted).