### PR TITLE
Avoid Yjs warnings during cell insertion

### DIFF
--- a/javascript/src/ycell.ts
+++ b/javascript/src/ycell.ts
@@ -165,18 +165,13 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
     this.ymodel = ymodel;
     this._ysource = ysource;
     this._ymetadata = ymetadata ?? this.ymodel.get('metadata');
-    this._prevSourceLength = ysource ? ysource.length : 0;
+    this._prevSourceLength = this.ymodel.doc == null ? 0 : ysource.length;
     this._notebook = null;
     this._awareness = null;
     this._undoManager = null;
     if (options.notebook) {
       this._notebook = options.notebook as YNotebook;
-      if (this._notebook.disableDocumentWideUndoRedo) {
-        this._undoManager = new Y.UndoManager([this.ymodel], {
-          trackedOrigins: new Set([this]),
-          doc: this._notebook.ydoc
-        });
-      }
+      this._initializeUndoManager();
     } else {
       // Standalone cell
       const doc = new Y.Doc();
@@ -305,9 +300,11 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
     if (!this.notebook) {
       return this._undoManager;
     }
-    return this.notebook?.disableDocumentWideUndoRedo
-      ? this._undoManager
-      : this.notebook.undoManager;
+    if (this.notebook.disableDocumentWideUndoRedo) {
+      this._initializeUndoManager();
+      return this._undoManager;
+    }
+    return this.notebook.undoManager;
   }
 
   readonly ymodel: Y.Map<any>;
@@ -410,7 +407,9 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
    */
   setSource(value: string): void {
     this.transact(() => {
-      this.ysource.delete(0, this.ysource.length);
+      if (this.ysource.doc != null) {
+        this.ysource.delete(0, this.ysource.length);
+      }
       this.ysource.insert(0, value);
     });
     this.dirty = true;
@@ -554,7 +553,10 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
       } else if (clone?.jupyter?.outputs_hidden != null) {
         clone.collapsed = clone.jupyter.outputs_hidden;
       }
-      if (!JSONExt.deepEqual(clone, this.getMetadata())) {
+      if (
+        this._ymetadata.doc == null ||
+        !JSONExt.deepEqual(clone, this.getMetadata())
+      ) {
         this.transact(() => {
           for (const [key, value] of Object.entries(clone)) {
             this._ymetadata.set(key, value);
@@ -585,6 +587,7 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
    * @param undoable Whether to track the change in the action history or not (default `true`)
    */
   transact(f: () => void, undoable = true, origin: any = null): void {
+    this._initializeUndoManager();
     !this.notebook || this.notebook.disableDocumentWideUndoRedo
       ? this.ymodel.doc == null
         ? f()
@@ -685,6 +688,19 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
     }
   };
 
+  private _initializeUndoManager(): void {
+    if (
+      this._undoManager == null &&
+      this._notebook?.disableDocumentWideUndoRedo &&
+      this.ymodel.doc === this._notebook.ydoc
+    ) {
+      this._undoManager = new Y.UndoManager([this.ymodel], {
+        trackedOrigins: new Set([this]),
+        doc: this._notebook.ydoc
+      });
+    }
+  }
+
   protected _metadataChanged = new Signal<this, IMapChange>(this);
   /**
    * The notebook that this cell belongs to.
@@ -766,7 +782,10 @@ export class YCodeCell
     // cell, we need to set execution_count to `null` if we compare
     // using `this.execution_count` it will return `null` and we will
     // never initialize it
-    if (this.ymodel.get('execution_count') !== count) {
+    if (
+      this.ymodel.doc == null ||
+      this.ymodel.get('execution_count') !== count
+    ) {
       this.transact(() => {
         this.ymodel.set('execution_count', count);
       }, false);
@@ -838,7 +857,9 @@ export class YCodeCell
    */
   setOutputs(outputs: Array<nbformat.IOutput>): void {
     this.transact(() => {
-      this._youtputs.delete(0, this._youtputs.length);
+      if (this._youtputs.doc != null) {
+        this._youtputs.delete(0, this._youtputs.length);
+      }
       const newOutputs = this.createOutputs(outputs);
       this._youtputs.insert(0, newOutputs);
     }, false);

--- a/javascript/src/ycell.ts
+++ b/javascript/src/ycell.ts
@@ -165,13 +165,18 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
     this.ymodel = ymodel;
     this._ysource = ysource;
     this._ymetadata = ymetadata ?? this.ymodel.get('metadata');
-    this._prevSourceLength = this.ymodel.doc == null ? 0 : ysource.length;
+    this._prevSourceLength = ysource ? ysource.length : 0;
     this._notebook = null;
     this._awareness = null;
     this._undoManager = null;
     if (options.notebook) {
       this._notebook = options.notebook as YNotebook;
-      this._initializeUndoManager();
+      if (this._notebook.disableDocumentWideUndoRedo) {
+        this._undoManager = new Y.UndoManager([this.ymodel], {
+          trackedOrigins: new Set([this]),
+          doc: this._notebook.ydoc
+        });
+      }
     } else {
       // Standalone cell
       const doc = new Y.Doc();
@@ -300,11 +305,9 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
     if (!this.notebook) {
       return this._undoManager;
     }
-    if (this.notebook.disableDocumentWideUndoRedo) {
-      this._initializeUndoManager();
-      return this._undoManager;
-    }
-    return this.notebook.undoManager;
+    return this.notebook?.disableDocumentWideUndoRedo
+      ? this._undoManager
+      : this.notebook.undoManager;
   }
 
   readonly ymodel: Y.Map<any>;
@@ -407,9 +410,7 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
    */
   setSource(value: string): void {
     this.transact(() => {
-      if (this.ysource.doc != null) {
-        this.ysource.delete(0, this.ysource.length);
-      }
+      this.ysource.delete(0, this.ysource.length);
       this.ysource.insert(0, value);
     });
     this.dirty = true;
@@ -553,10 +554,7 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
       } else if (clone?.jupyter?.outputs_hidden != null) {
         clone.collapsed = clone.jupyter.outputs_hidden;
       }
-      if (
-        this._ymetadata.doc == null ||
-        !JSONExt.deepEqual(clone, this.getMetadata())
-      ) {
+      if (!JSONExt.deepEqual(clone, this.getMetadata())) {
         this.transact(() => {
           for (const [key, value] of Object.entries(clone)) {
             this._ymetadata.set(key, value);
@@ -587,7 +585,6 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
    * @param undoable Whether to track the change in the action history or not (default `true`)
    */
   transact(f: () => void, undoable = true, origin: any = null): void {
-    this._initializeUndoManager();
     !this.notebook || this.notebook.disableDocumentWideUndoRedo
       ? this.ymodel.doc == null
         ? f()
@@ -688,19 +685,6 @@ export class YBaseCell<Metadata extends nbformat.IBaseCellMetadata>
     }
   };
 
-  private _initializeUndoManager(): void {
-    if (
-      this._undoManager == null &&
-      this._notebook?.disableDocumentWideUndoRedo &&
-      this.ymodel.doc === this._notebook.ydoc
-    ) {
-      this._undoManager = new Y.UndoManager([this.ymodel], {
-        trackedOrigins: new Set([this]),
-        doc: this._notebook.ydoc
-      });
-    }
-  }
-
   protected _metadataChanged = new Signal<this, IMapChange>(this);
   /**
    * The notebook that this cell belongs to.
@@ -782,10 +766,7 @@ export class YCodeCell
     // cell, we need to set execution_count to `null` if we compare
     // using `this.execution_count` it will return `null` and we will
     // never initialize it
-    if (
-      this.ymodel.doc == null ||
-      this.ymodel.get('execution_count') !== count
-    ) {
+    if (this.ymodel.get('execution_count') !== count) {
       this.transact(() => {
         this.ymodel.set('execution_count', count);
       }, false);
@@ -857,9 +838,7 @@ export class YCodeCell
    */
   setOutputs(outputs: Array<nbformat.IOutput>): void {
     this.transact(() => {
-      if (this._youtputs.doc != null) {
-        this._youtputs.delete(0, this._youtputs.length);
-      }
+      this._youtputs.delete(0, this._youtputs.length);
       const newOutputs = this.createOutputs(outputs);
       this._youtputs.insert(0, newOutputs);
     }, false);

--- a/javascript/test/ynotebook.spec.ts
+++ b/javascript/test/ynotebook.spec.ts
@@ -591,6 +591,42 @@ describe('@jupyter/ydoc', () => {
       });
 
       describe('per cells', () => {
+        test('should not warn when inserting a cell', () => {
+          const warn = jest.spyOn(console, 'warn').mockImplementation();
+          const notebook = YNotebook.create({
+            disableDocumentWideUndoRedo: true
+          });
+
+          try {
+            notebook.insertCell(0, {
+              cell_type: 'code',
+              source: 'print("hello")',
+              metadata: {},
+              outputs: [],
+              execution_count: null
+            });
+
+            expect(warn).not.toHaveBeenCalled();
+          } finally {
+            warn.mockRestore();
+            notebook.dispose();
+          }
+        });
+
+        test('should create cell undo manager after inserting a cell', () => {
+          const notebook = YNotebook.create({
+            disableDocumentWideUndoRedo: true
+          });
+
+          try {
+            const cell = notebook.addCell({ cell_type: 'code' });
+
+            expect(cell.undoManager).not.toBeNull();
+          } finally {
+            notebook.dispose();
+          }
+        });
+
         test('should undo cell addition', () => {
           const notebook = YNotebook.create({
             disableDocumentWideUndoRedo: true

--- a/yarn.lock
+++ b/yarn.lock
@@ -4267,12 +4267,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lib0@npm:^0.2.31, lib0@npm:^0.2.42, lib0@npm:^0.2.49, lib0@npm:^0.2.52":
+"lib0@npm:^0.2.31, lib0@npm:^0.2.42, lib0@npm:^0.2.52":
   version: 0.2.58
   resolution: "lib0@npm:0.2.58"
   dependencies:
     isomorphic.js: ^0.2.4
   checksum: 90136b972af1468e71c6c2f453297e88a7631f4eb8efcedb18125da4c8a53e769c42c512467c8a8b8d164949999bc212a3a9ed710b958b287a913a177ced6847
+  languageName: node
+  linkType: hard
+
+"lib0@npm:^0.2.99":
+  version: 0.2.117
+  resolution: "lib0@npm:0.2.117"
+  dependencies:
+    isomorphic.js: ^0.2.4
+  bin:
+    0ecdsa-generate-keypair: bin/0ecdsa-generate-keypair.js
+    0gentesthtml: bin/gentesthtml.js
+    0serve: bin/0serve.js
+  checksum: 948a6bb292cc643bcaea948b82f72a05edb83ff172803ba0ebdbf87361f6446d2877b61611f20ccd377c7bfa0453925b27ea75db8b694abab84216c6ca50325c
   languageName: node
   linkType: hard
 
@@ -6119,11 +6132,11 @@ __metadata:
   linkType: hard
 
 "yjs@npm:^13.5.40":
-  version: 13.5.44
-  resolution: "yjs@npm:13.5.44"
+  version: 13.6.31
+  resolution: "yjs@npm:13.6.31"
   dependencies:
-    lib0: ^0.2.49
-  checksum: a43a960605f82338e46fcf245d083095934689f3425d7f085f5ab4ea365095f0dee56e5dcaed9cba669971b4a6a073966964888fea9b0a2c15a041ebb58bcbdc
+    lib0: ^0.2.99
+  checksum: 87c665c53344d48a3b85d21fa409d2a51bbdc995292a0c1bdfb1493620d4ba6c7cd1a308155642942fc45fa59e8d4557caab03d559f9408451ee6984ef180425
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes https://github.com/jupyterlab/jupyterlab/issues/19022

Fixes premature Yjs access when inserting notebook cells with per-cell undo enabled. The cell now avoids reading unattached Yjs types during initialization and creates its per-cell undo manager only after the cell belongs to the notebook document. Adds regression coverage for the direct `YNotebook.create({ disableDocumentWideUndoRedo: true }).insertCell(...)` warning path and immediate `cell.undoManager` availability.